### PR TITLE
Fix Codecov upload and add Quay.io badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,11 +65,11 @@ jobs:
       - name: Run tests with race detector
         run: go test -v -count=1 -race ./...
       - name: Run tests with coverage
-        run: go test -coverprofile=coverage.out -count=1 ./...
-      - name: Upload coverage to Codecov
+        run: go test -coverprofile=coverage.txt -count=1 ./...
+      - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Go Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dwarfbot
 
-[![codecov](https://codecov.io/gh/clcollins/dwarfbot/graph/badge.svg)](https://codecov.io/gh/clcollins/dwarfbot)
+[![codecov](https://codecov.io/gh/clcollins/dwarfbot/graph/badge.svg)](https://codecov.io/gh/clcollins/dwarfbot) [![Docker Repository on Quay](https://quay.io/repository/clcollins/dwarfbot/status "Docker Repository on Quay")](https://quay.io/repository/clcollins/dwarfbot)
 
 The cheerful sidekick from
 [https://twitch.tv/hammerdwarf](https://twitch.tv/hammerdwarf),


### PR DESCRIPTION
## Summary

- Fix Codecov integration: use `token: ${{ secrets.CODECOV_TOKEN }}` auth (v5 requirement) instead of `files:` parameter
- Add Quay.io container image status badge to README alongside Codecov badge

## Test plan

- [ ] CI passes
- [ ] Codecov upload succeeds (check https://app.codecov.io/gh/clcollins/dwarfbot after merge)
- [ ] Quay.io badge renders in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)