### PR TITLE
Add graceful Twitch shutdown via Stop() method

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,8 +131,9 @@ var rootCmd = &cobra.Command{
 
 		// Start Twitch bot if configured (non-fatal on failure)
 		twitchErrCh := make(chan error, 1)
+		var twitchBot *dwarfbot.DwarfBot
 		if twitchEnabled {
-			bot := dwarfbot.DwarfBot{
+			twitchBot = &dwarfbot.DwarfBot{
 				Credentials: &dwarfbot.OAuthCreds{
 					Name:  name,
 					Token: twitchToken,
@@ -146,7 +147,7 @@ var rootCmd = &cobra.Command{
 			}
 
 			go func() {
-				twitchErrCh <- bot.Start()
+				twitchErrCh <- twitchBot.Start()
 			}()
 		}
 
@@ -159,6 +160,15 @@ var rootCmd = &cobra.Command{
 		select {
 		case <-sc:
 			log.Println("Shutting down...")
+			if twitchBot != nil {
+				twitchBot.Stop()
+				// Wait for Twitch goroutine to finish (with timeout)
+				select {
+				case <-twitchErrCh:
+				case <-time.After(5 * time.Second):
+					log.Println("Twitch bot did not stop within timeout")
+				}
+			}
 		case err := <-twitchErrCh:
 			if err != nil {
 				log.Printf("Twitch bot exited with error: %v", err)

--- a/docs/plan-graceful-shutdown.md
+++ b/docs/plan-graceful-shutdown.md
@@ -1,0 +1,45 @@
+# Plan: Graceful Twitch Shutdown
+
+## Context
+
+When the process received SIGINT/SIGTERM, the Twitch bot goroutine
+didn't get a clean shutdown signal. `DwarfBot.Start()` runs an
+infinite reconnect loop, and `HandleChat()` blocks indefinitely on
+`tp.ReadLine()`. The deferred `Disconnect()` in `Start()` never
+ran because the goroutine was killed when the process exited.
+
+Discord didn't have this problem because its cleanup runs via
+`defer discordBot.Stop()` in the main goroutine.
+
+## Lessons from Prior Plans
+
+- **plan-unit-tests.md**: Tests use `conn.Close()` from outside
+  to unblock `HandleChat()` — the proven shutdown mechanism
+- **plan-resilience-and-metrics.md**: `PlatformMetrics` nil-guard
+  pattern; `mockMetricsRecorder` for test assertions
+
+## Changes Made
+
+### `Stop()` method on DwarfBot
+
+Added a mutex-protected `stopped` flag and a `Stop()` method that
+sets it and closes the connection. Closing the connection
+immediately unblocks any pending `ReadLine()` in `HandleChat()`.
+
+### `Start()` checks `stopped` flag
+
+The reconnect loop now checks `isStopped()` before reconnecting.
+When `HandleChat()` returns an error after `Stop()` was called,
+`Start()` returns nil (clean shutdown) instead of reconnecting.
+
+### `cmd/root.go` calls `Stop()` on signal
+
+The signal handler now calls `twitchBot.Stop()` and waits up to
+5 seconds for the goroutine to finish before proceeding with
+metrics server shutdown.
+
+### Why not context.Context?
+
+`ReadLine()` doesn't accept a context. You'd still need to close
+the conn to unblock it. The `Stop()` approach achieves the same
+result with no interface changes and minimal code.

--- a/pkg/dwarfbot/dwarfbot.go
+++ b/pkg/dwarfbot/dwarfbot.go
@@ -95,7 +95,8 @@ type DwarfBot struct {
 	// lastDisconnectReason tracks why the connection was lost for metrics.
 	lastDisconnectReason string
 
-	// mu protects stopped flag for concurrent access from Stop().
+	// mu protects stopped, lastDisconnectReason, and conn for
+	// concurrent access between the bot goroutine and Stop().
 	mu      sync.Mutex
 	stopped bool
 }
@@ -106,9 +107,10 @@ func (db *DwarfBot) Stop() {
 	db.mu.Lock()
 	db.stopped = true
 	db.lastDisconnectReason = "shutdown"
+	conn := db.conn
 	db.mu.Unlock()
-	if db.conn != nil {
-		_ = db.conn.Close()
+	if conn != nil {
+		_ = conn.Close()
 	}
 }
 
@@ -116,6 +118,15 @@ func (db *DwarfBot) isStopped() bool {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	return db.stopped
+}
+
+func (db *DwarfBot) setDisconnectReason(reason string) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	// Don't overwrite "shutdown" with an error reason
+	if db.lastDisconnectReason != "shutdown" {
+		db.lastDisconnectReason = reason
+	}
 }
 
 func (db *DwarfBot) Start() error {
@@ -167,6 +178,9 @@ func (db *DwarfBot) Connect() error {
 
 	maxRetries := 10
 	for attempt := range maxRetries {
+		if db.isStopped() {
+			return fmt.Errorf("connect aborted: bot is stopping")
+		}
 		var err error
 		db.conn, err = net.Dial("tcp", db.Server+":"+db.Port)
 		if err == nil {
@@ -201,13 +215,15 @@ func (db *DwarfBot) Disconnect() {
 	duration := time.Since(db.startTime)
 	log.Printf("Connection closed; elapsed time %g", duration.Seconds())
 	if db.Metrics != nil {
+		db.mu.Lock()
 		reason := "shutdown"
 		if db.lastDisconnectReason != "" {
 			reason = db.lastDisconnectReason
 		}
+		db.lastDisconnectReason = ""
+		db.mu.Unlock()
 		db.Metrics.RecordDisconnected("twitch", reason)
 		db.Metrics.RecordConnectionDuration("twitch", duration)
-		db.lastDisconnectReason = ""
 	}
 }
 
@@ -263,7 +279,7 @@ func (db *DwarfBot) HandleChat() error {
 	for {
 		line, err := tp.ReadLine()
 		if err != nil {
-			db.lastDisconnectReason = "read_error"
+			db.setDisconnectReason("read_error")
 			db.Disconnect()
 
 			return fmt.Errorf("failed to read line from channel, disconnecting: %w", err)
@@ -278,7 +294,7 @@ func (db *DwarfBot) HandleChat() error {
 			// Must reply to PING messages with PONG message to stay connected
 			pong := "PONG :tmi.twitch.tv\r\n"
 			if _, err := db.conn.Write([]byte(pong)); err != nil {
-				db.lastDisconnectReason = "write_error"
+				db.setDisconnectReason("write_error")
 				db.Disconnect()
 				return fmt.Errorf("failed to write PONG to server, disconnecting: %w", err)
 			}

--- a/pkg/dwarfbot/dwarfbot.go
+++ b/pkg/dwarfbot/dwarfbot.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -93,6 +94,28 @@ type DwarfBot struct {
 
 	// lastDisconnectReason tracks why the connection was lost for metrics.
 	lastDisconnectReason string
+
+	// mu protects stopped flag for concurrent access from Stop().
+	mu      sync.Mutex
+	stopped bool
+}
+
+// Stop signals the bot to shut down cleanly by closing the connection,
+// which unblocks any pending ReadLine() in HandleChat().
+func (db *DwarfBot) Stop() {
+	db.mu.Lock()
+	db.stopped = true
+	db.lastDisconnectReason = "shutdown"
+	db.mu.Unlock()
+	if db.conn != nil {
+		_ = db.conn.Close()
+	}
+}
+
+func (db *DwarfBot) isStopped() bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.stopped
 }
 
 func (db *DwarfBot) Start() error {
@@ -101,6 +124,11 @@ func (db *DwarfBot) Start() error {
 	log.Println("dwarfbot is starting...")
 
 	for {
+		if db.isStopped() {
+			log.Println("Twitch bot stopped")
+			return nil
+		}
+
 		if db.Verbose {
 			log.Println("dwarfbot is waiting for a command...")
 		}
@@ -120,6 +148,10 @@ func (db *DwarfBot) Start() error {
 
 		err := db.HandleChat()
 		if err != nil {
+			if db.isStopped() {
+				log.Println("Twitch bot stopped")
+				return nil
+			}
 			log.Println(err)
 			db.Disconnect()
 			time.Sleep(time.Second)

--- a/pkg/dwarfbot/dwarfbot.go
+++ b/pkg/dwarfbot/dwarfbot.go
@@ -99,6 +99,7 @@ type DwarfBot struct {
 	// concurrent access between the bot goroutine and Stop().
 	mu      sync.Mutex
 	stopped bool
+	stopCh  chan struct{}
 }
 
 // Stop signals the bot to shut down cleanly by closing the connection,
@@ -108,6 +109,13 @@ func (db *DwarfBot) Stop() {
 	db.stopped = true
 	db.lastDisconnectReason = "shutdown"
 	conn := db.conn
+	if db.stopCh != nil {
+		select {
+		case <-db.stopCh:
+		default:
+			close(db.stopCh)
+		}
+	}
 	db.mu.Unlock()
 	if conn != nil {
 		_ = conn.Close()
@@ -123,13 +131,22 @@ func (db *DwarfBot) isStopped() bool {
 func (db *DwarfBot) setDisconnectReason(reason string) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	// Don't overwrite "shutdown" with an error reason
 	if db.lastDisconnectReason != "shutdown" {
 		db.lastDisconnectReason = reason
 	}
 }
 
+func (db *DwarfBot) setConn(conn net.Conn) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.conn = conn
+}
+
 func (db *DwarfBot) Start() error {
+	db.mu.Lock()
+	db.stopCh = make(chan struct{})
+	db.mu.Unlock()
+
 	defer db.Disconnect()
 
 	log.Println("dwarfbot is starting...")
@@ -145,14 +162,15 @@ func (db *DwarfBot) Start() error {
 		}
 
 		if err := db.Connect(); err != nil {
+			if db.isStopped() {
+				log.Println("Twitch bot stopped")
+				return nil
+			}
 			return fmt.Errorf("twitch connection failed: %w", err)
 		}
 		db.Authenticate()
 
-		// Join the bot's channel
 		db.JoinChannel(db.Name)
-
-		// Join secondary channels
 		for _, channel := range db.Channels {
 			db.JoinChannel(channel)
 		}
@@ -181,9 +199,9 @@ func (db *DwarfBot) Connect() error {
 		if db.isStopped() {
 			return fmt.Errorf("connect aborted: bot is stopping")
 		}
-		var err error
-		db.conn, err = net.Dial("tcp", db.Server+":"+db.Port)
+		conn, err := net.Dial("tcp", db.Server+":"+db.Port)
 		if err == nil {
+			db.setConn(conn)
 			db.startTime = time.Now()
 			log.Printf("Connected to %s", db.Server)
 			if db.Metrics != nil {
@@ -197,7 +215,20 @@ func (db *DwarfBot) Connect() error {
 		}
 		backoff := time.Duration(attempt+1) * time.Second
 		log.Printf("Failed connecting to %s, retrying in %v...\n", db.Server, backoff)
-		time.Sleep(backoff)
+
+		// Interruptible backoff — returns immediately if Stop() is called
+		db.mu.Lock()
+		stopCh := db.stopCh
+		db.mu.Unlock()
+		if stopCh != nil {
+			select {
+			case <-stopCh:
+				return fmt.Errorf("connect aborted: bot is stopping")
+			case <-time.After(backoff):
+			}
+		} else {
+			time.Sleep(backoff)
+		}
 	}
 
 	return fmt.Errorf("failed to connect to %s after %d attempts", db.Server, maxRetries)
@@ -205,23 +236,25 @@ func (db *DwarfBot) Connect() error {
 
 // Disconnect closes the IRC connection. Safe to call multiple times.
 func (db *DwarfBot) Disconnect() {
-	if db.conn == nil {
+	db.mu.Lock()
+	conn := db.conn
+	db.conn = nil
+	reason := "shutdown"
+	if db.lastDisconnectReason != "" {
+		reason = db.lastDisconnectReason
+	}
+	db.lastDisconnectReason = ""
+	db.mu.Unlock()
+
+	if conn == nil {
 		return
 	}
-	if err := db.conn.Close(); err != nil {
+	if err := conn.Close(); err != nil {
 		log.Printf("Error closing connection: %v", err)
 	}
-	db.conn = nil // prevent double-close
 	duration := time.Since(db.startTime)
 	log.Printf("Connection closed; elapsed time %g", duration.Seconds())
 	if db.Metrics != nil {
-		db.mu.Lock()
-		reason := "shutdown"
-		if db.lastDisconnectReason != "" {
-			reason = db.lastDisconnectReason
-		}
-		db.lastDisconnectReason = ""
-		db.mu.Unlock()
 		db.Metrics.RecordDisconnected("twitch", reason)
 		db.Metrics.RecordConnectionDuration("twitch", duration)
 	}

--- a/pkg/dwarfbot/dwarfbot_test.go
+++ b/pkg/dwarfbot/dwarfbot_test.go
@@ -1211,17 +1211,12 @@ func TestStop_UnblocksHandleChat(t *testing.T) {
 		errCh <- bot.HandleChat()
 	}()
 
-	// Give HandleChat time to start blocking on ReadLine
-	time.Sleep(50 * time.Millisecond)
-
+	// Call Stop immediately — it closes the conn which unblocks ReadLine
 	bot.Stop()
 
 	select {
-	case err := <-errCh:
-		// HandleChat should return an error (connection closed)
-		if err == nil {
-			// This is also OK if isStopped was checked before the error
-		}
+	case <-errCh:
+		// HandleChat returned (error or nil, both OK)
 	case <-time.After(2 * time.Second):
 		t.Fatal("HandleChat did not return after Stop() within timeout")
 	}
@@ -1233,7 +1228,8 @@ func TestStop_UnblocksHandleChat(t *testing.T) {
 
 func TestStop_RecordsShutdownMetric(t *testing.T) {
 	rec := newMockMetricsRecorder()
-	_, client := net.Pipe()
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
 	bot := &DwarfBot{
 		conn:      client,
 		startTime: time.Now(),
@@ -1241,11 +1237,28 @@ func TestStop_RecordsShutdownMetric(t *testing.T) {
 	}
 
 	bot.Stop()
+	// Drive through Disconnect to trigger metric recording
+	bot.Disconnect()
 
-	// The conn close triggers Disconnect via Start's defer in production,
-	// but here we manually verify the lastDisconnectReason was set
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.disconnected) != 1 {
+		t.Fatalf("expected 1 disconnect metric, got %d", len(rec.disconnected))
+	}
+	if rec.disconnected[0].reason != "shutdown" {
+		t.Errorf("expected reason 'shutdown', got %q", rec.disconnected[0].reason)
+	}
+}
+
+func TestSetDisconnectReason_DoesNotOverwriteShutdown(t *testing.T) {
+	bot := &DwarfBot{}
+	bot.Stop() // sets lastDisconnectReason = "shutdown"
+	bot.setDisconnectReason("read_error")
+
+	bot.mu.Lock()
+	defer bot.mu.Unlock()
 	if bot.lastDisconnectReason != "shutdown" {
-		t.Errorf("expected lastDisconnectReason='shutdown', got %q", bot.lastDisconnectReason)
+		t.Errorf("expected 'shutdown' preserved, got %q", bot.lastDisconnectReason)
 	}
 }
 

--- a/pkg/dwarfbot/dwarfbot_test.go
+++ b/pkg/dwarfbot/dwarfbot_test.go
@@ -1180,5 +1180,95 @@ func TestNormalizeCommandLabel(t *testing.T) {
 	}
 }
 
+// --- Stop / graceful shutdown tests ---
+
+func TestStop_SetsStoppedFlag(t *testing.T) {
+	bot := &DwarfBot{}
+	if bot.isStopped() {
+		t.Error("expected isStopped=false initially")
+	}
+	bot.Stop()
+	if !bot.isStopped() {
+		t.Error("expected isStopped=true after Stop()")
+	}
+}
+
+func TestStop_NilConn(t *testing.T) {
+	bot := &DwarfBot{}
+	// Should not panic with nil conn
+	bot.Stop()
+	if !bot.isStopped() {
+		t.Error("expected stopped after Stop()")
+	}
+}
+
+func TestStop_UnblocksHandleChat(t *testing.T) {
+	bot, _, cleanup := newTestBot(t)
+	defer cleanup()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- bot.HandleChat()
+	}()
+
+	// Give HandleChat time to start blocking on ReadLine
+	time.Sleep(50 * time.Millisecond)
+
+	bot.Stop()
+
+	select {
+	case err := <-errCh:
+		// HandleChat should return an error (connection closed)
+		if err == nil {
+			// This is also OK if isStopped was checked before the error
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleChat did not return after Stop() within timeout")
+	}
+
+	if !bot.isStopped() {
+		t.Error("expected isStopped=true")
+	}
+}
+
+func TestStop_RecordsShutdownMetric(t *testing.T) {
+	rec := newMockMetricsRecorder()
+	_, client := net.Pipe()
+	bot := &DwarfBot{
+		conn:      client,
+		startTime: time.Now(),
+		Metrics:   rec,
+	}
+
+	bot.Stop()
+
+	// The conn close triggers Disconnect via Start's defer in production,
+	// but here we manually verify the lastDisconnectReason was set
+	if bot.lastDisconnectReason != "shutdown" {
+		t.Errorf("expected lastDisconnectReason='shutdown', got %q", bot.lastDisconnectReason)
+	}
+}
+
+func TestStart_ReturnsNilOnStop(t *testing.T) {
+	bot := &DwarfBot{
+		Server: "localhost",
+		Port:   "6667",
+		Name:   "testbot",
+		Credentials: &OAuthCreds{
+			Name:  "testbot",
+			Token: "test_token",
+		},
+		exitFunc: func(int) {},
+	}
+
+	// Pre-set stopped so Start exits immediately
+	bot.Stop()
+
+	err := bot.Start()
+	if err != nil {
+		t.Errorf("expected nil error from Start() when pre-stopped, got %v", err)
+	}
+}
+
 // Verify DwarfBot satisfies ChatPlatform at compile time
 var _ ChatPlatform = (*DwarfBot)(nil)

--- a/pkg/dwarfbot/dwarfbot_test.go
+++ b/pkg/dwarfbot/dwarfbot_test.go
@@ -1250,6 +1250,46 @@ func TestStop_RecordsShutdownMetric(t *testing.T) {
 	}
 }
 
+func TestSetConn(t *testing.T) {
+	bot := &DwarfBot{}
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	defer func() { _ = client.Close() }()
+
+	bot.setConn(client)
+	bot.mu.Lock()
+	if bot.conn != client {
+		t.Error("expected conn to be set")
+	}
+	bot.mu.Unlock()
+}
+
+func TestStop_ClosesStopChannel(t *testing.T) {
+	bot := &DwarfBot{
+		stopCh: make(chan struct{}),
+	}
+	bot.Stop()
+
+	// stopCh should be closed
+	select {
+	case <-bot.stopCh:
+		// good, channel is closed
+	default:
+		t.Error("expected stopCh to be closed after Stop()")
+	}
+}
+
+func TestStop_DoubleStopSafe(t *testing.T) {
+	bot := &DwarfBot{
+		stopCh: make(chan struct{}),
+	}
+	bot.Stop()
+	bot.Stop() // should not panic
+	if !bot.isStopped() {
+		t.Error("expected stopped after double Stop()")
+	}
+}
+
 func TestSetDisconnectReason_DoesNotOverwriteShutdown(t *testing.T) {
 	bot := &DwarfBot{}
 	bot.Stop() // sets lastDisconnectReason = "shutdown"


### PR DESCRIPTION
## Summary

- Add `Stop()` method to `DwarfBot` that sets a stopped flag and closes the connection, unblocking `HandleChat()`'s `ReadLine()` call
- `Start()` now checks `isStopped()` and returns nil (clean exit) instead of reconnecting
- `cmd/root.go` calls `twitchBot.Stop()` on SIGINT/SIGTERM and waits up to 5s for the goroutine to finish
- Disconnect metrics now correctly recorded with "shutdown" reason on clean exit
- 5 new tests for Stop/isStopped/clean shutdown paths

## Problem

Previously, SIGINT/SIGTERM killed the Twitch goroutine without cleanup — no disconnect metrics, no connection duration recorded, no QUIT message sent to IRC.

## Test plan

- [x] `make ci` passes
- [x] `go test -race ./...` — no data races
- [ ] Manual: run bot, Ctrl+C, verify "Twitch bot stopped" logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)