### PR TITLE
Add automated multi-arch container image builds and pushes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+out/
+docs/
+img/
+deploy/
+*.md
+LICENSE
+.markdownlint.yaml
+.dwarfbot.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
       - name: Build container image
-        run: podman build -f Containerfile -t ${{ env.IMAGE_NAME }}:ci .
+        run: |
+          podman build -f Containerfile \
+            --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            --build-arg VCS_REF=$(git rev-parse HEAD) \
+            --build-arg VERSION=ci \
+            -t ${{ env.IMAGE_NAME }}:ci .
+      - name: Validate OCI labels
+        run: |
+          echo "Checking OCI labels..."
+          podman inspect ${{ env.IMAGE_NAME }}:ci --format '{{index .Config.Labels "org.opencontainers.image.title"}}' | grep -q "dwarfbot"
+          podman inspect ${{ env.IMAGE_NAME }}:ci --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' | grep -q "$(git rev-parse HEAD)"
+          podman inspect ${{ env.IMAGE_NAME }}:ci --format '{{index .Config.Labels "org.opencontainers.image.version"}}' | grep -q "ci"
+          podman inspect ${{ env.IMAGE_NAME }}:ci --format '{{index .Config.Labels "is.collins.cluster.build.commit.id"}}' | grep -q "$(git rev-parse HEAD)"
+          podman inspect ${{ env.IMAGE_NAME }}:ci --format '{{index .Config.Labels "io.k8s.display-name"}}' | grep -q "dwarfbot"
+          echo "All OCI labels validated successfully."
+      - name: Validate image runs
+        run: podman run --rm ${{ env.IMAGE_NAME }}:ci --help
 
   checkmake:
     name: Makefile Lint

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -92,20 +92,20 @@ jobs:
           SHORT_SHA="${{ steps.meta.outputs.short_sha }}"
           TAGS="${{ steps.meta.outputs.tags }}"
 
+          # Create manifest with both local architectures
+          podman manifest create "${FULL_IMAGE}:${SHORT_SHA}"
+          podman manifest add "${FULL_IMAGE}:${SHORT_SHA}" \
+            "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-amd64"
+          podman manifest add "${FULL_IMAGE}:${SHORT_SHA}" \
+            "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64"
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Pull request build - skipping manifest creation and push."
+            echo "Pull request build - manifest created locally; skipping registry push."
             echo "Tags that would be pushed: ${TAGS}"
             echo "Built images:"
             podman images --filter "reference=${FULL_IMAGE}" --format "{{.Repository}}:{{.Tag}}"
             exit 0
           fi
-
-          # Create manifest with both local architectures
-          podman manifest create ${FULL_IMAGE}:${SHORT_SHA}
-          podman manifest add ${FULL_IMAGE}:${SHORT_SHA} \
-            containers-storage:${FULL_IMAGE}:${SHORT_SHA}-amd64
-          podman manifest add ${FULL_IMAGE}:${SHORT_SHA} \
-            containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64
 
           # Push the manifest under each tag
           for TAG in ${TAGS}; do

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -10,6 +10,7 @@ on:
 env:
   REGISTRY: quay.io
   IMAGE_NAME: clcollins/dwarfbot
+  CONTAINER_FILE: Containerfile
 
 jobs:
   image-build-push:
@@ -21,44 +22,90 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Install QEMU for multi-arch builds
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set build metadata
+        id: meta
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          FULL_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+          echo "full_image=${FULL_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          # Build tag list
+          TAGS="${FULL_IMAGE}:${SHORT_SHA}"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            TAGS="${TAGS} ${FULL_IMAGE}:pr-${PR_NUMBER}"
+            echo "version=pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${{ github.ref_name }}"
+            TAGS="${TAGS} ${FULL_IMAGE}:${VERSION}"
+            # Also tag without 'v' prefix if present (e.g., v0.2.0 -> 0.2.0)
+            VERSION_NO_V="${VERSION#v}"
+            if [ "${VERSION_NO_V}" != "${VERSION}" ]; then
+              TAGS="${TAGS} ${FULL_IMAGE}:${VERSION_NO_V}"
+            fi
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            TAGS="${TAGS} ${FULL_IMAGE}:latest"
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          podman login quay.io \
+            --username "${{ secrets.QUAY_USERNAME }}" \
+            --password "${{ secrets.QUAY_PASSWORD }}"
 
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=pr,prefix=pr-
-            type=sha,prefix=,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern=v{{version}}
+      - name: Build linux/amd64 image
+        run: |
+          podman build -f ${{ env.CONTAINER_FILE }} \
+            --platform linux/amd64 \
+            --build-arg BUILD_DATE=${{ steps.meta.outputs.build_date }} \
+            --build-arg VCS_REF=${{ github.sha }} \
+            --build-arg VERSION=${{ steps.meta.outputs.version }} \
+            -t ${{ steps.meta.outputs.full_image }}:${{ steps.meta.outputs.short_sha }}-amd64 .
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at }}
-            VCS_REF=${{ github.sha }}
-            VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build linux/arm64 image
+        run: |
+          podman build -f ${{ env.CONTAINER_FILE }} \
+            --platform linux/arm64 \
+            --build-arg BUILD_DATE=${{ steps.meta.outputs.build_date }} \
+            --build-arg VCS_REF=${{ github.sha }} \
+            --build-arg VERSION=${{ steps.meta.outputs.version }} \
+            -t ${{ steps.meta.outputs.full_image }}:${{ steps.meta.outputs.short_sha }}-arm64 .
+
+      - name: Create and push multi-arch manifest
+        run: |
+          FULL_IMAGE="${{ steps.meta.outputs.full_image }}"
+          SHORT_SHA="${{ steps.meta.outputs.short_sha }}"
+          TAGS="${{ steps.meta.outputs.tags }}"
+
+          # Create manifest with both architectures
+          podman manifest create ${FULL_IMAGE}:${SHORT_SHA} \
+            ${FULL_IMAGE}:${SHORT_SHA}-amd64 \
+            ${FULL_IMAGE}:${SHORT_SHA}-arm64
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push manifest under each tag
+            for TAG in ${TAGS}; do
+              if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
+                podman tag ${FULL_IMAGE}:${SHORT_SHA} "${TAG}"
+              fi
+              podman manifest push --all "${TAG}" "docker://${TAG}"
+            done
+          else
+            echo "Pull request build - skipping push."
+            echo "Tags that would be pushed: ${TAGS}"
+          fi

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -53,7 +53,7 @@ jobs:
             if [ "${VERSION_NO_V}" != "${VERSION}" ]; then
               TAGS="${TAGS} ${FULL_IMAGE}:${VERSION_NO_V}"
             fi
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=${VERSION_NO_V}" >> "$GITHUB_OUTPUT"
           else
             TAGS="${TAGS} ${FULL_IMAGE}:latest"
             echo "version=latest" >> "$GITHUB_OUTPUT"
@@ -99,10 +99,16 @@ jobs:
           podman manifest add "${FULL_IMAGE}:${SHORT_SHA}" \
             "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64"
 
+          # Apply all computed tags locally
+          for TAG in ${TAGS}; do
+            if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
+              podman tag "${FULL_IMAGE}:${SHORT_SHA}" "${TAG}"
+            fi
+          done
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Pull request build - manifest created locally; skipping registry push."
-            echo "Tags that would be pushed: ${TAGS}"
-            echo "Built images:"
+            echo "Pull request build - manifest created and tagged locally; skipping registry push."
+            echo "Local tags applied: ${TAGS}"
             podman images --filter "reference=${FULL_IMAGE}" --format "{{.Repository}}:{{.Tag}}"
             exit 0
           fi

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -92,20 +92,25 @@ jobs:
           SHORT_SHA="${{ steps.meta.outputs.short_sha }}"
           TAGS="${{ steps.meta.outputs.tags }}"
 
-          # Create manifest with both architectures
-          podman manifest create ${FULL_IMAGE}:${SHORT_SHA} \
-            ${FULL_IMAGE}:${SHORT_SHA}-amd64 \
-            ${FULL_IMAGE}:${SHORT_SHA}-arm64
-
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            # Push manifest under each tag
-            for TAG in ${TAGS}; do
-              if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
-                podman tag ${FULL_IMAGE}:${SHORT_SHA} "${TAG}"
-              fi
-              podman manifest push --all "${TAG}" "docker://${TAG}"
-            done
-          else
-            echo "Pull request build - skipping push."
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Pull request build - skipping manifest creation and push."
             echo "Tags that would be pushed: ${TAGS}"
+            echo "Built images:"
+            podman images --filter "reference=${FULL_IMAGE}" --format "{{.Repository}}:{{.Tag}}"
+            exit 0
           fi
+
+          # Create manifest with both local architectures
+          podman manifest create ${FULL_IMAGE}:${SHORT_SHA}
+          podman manifest add ${FULL_IMAGE}:${SHORT_SHA} \
+            containers-storage:${FULL_IMAGE}:${SHORT_SHA}-amd64
+          podman manifest add ${FULL_IMAGE}:${SHORT_SHA} \
+            containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64
+
+          # Push manifest under each tag
+          for TAG in ${TAGS}; do
+            if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
+              podman tag ${FULL_IMAGE}:${SHORT_SHA} "${TAG}"
+            fi
+            podman manifest push --all "${TAG}" "docker://${TAG}"
+          done

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -1,0 +1,64 @@
+name: Container Image Build & Push
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main]
+    tags: ['v*']
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: clcollins/dwarfbot
+
+jobs:
+  image-build-push:
+    name: Build & Push Container Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=pr-
+            type=sha,prefix=,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.pull_request.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install QEMU for multi-arch builds
+      - name: Install Podman and QEMU for multi-arch builds
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y podman qemu-user-static
 
       - name: Set build metadata
         id: meta
@@ -64,9 +64,9 @@ jobs:
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request'
         run: |
-          podman login quay.io \
+          echo "${{ secrets.QUAY_PASSWORD }}" | podman login quay.io \
             --username "${{ secrets.QUAY_USERNAME }}" \
-            --password "${{ secrets.QUAY_PASSWORD }}"
+            --password-stdin
 
       - name: Build linux/amd64 image
         run: |
@@ -107,10 +107,7 @@ jobs:
           podman manifest add ${FULL_IMAGE}:${SHORT_SHA} \
             containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64
 
-          # Push manifest under each tag
+          # Push the manifest under each tag
           for TAG in ${TAGS}; do
-            if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
-              podman tag ${FULL_IMAGE}:${SHORT_SHA} "${TAG}"
-            fi
-            podman manifest push --all "${TAG}" "docker://${TAG}"
+            podman manifest push --all "${FULL_IMAGE}:${SHORT_SHA}" "docker://${TAG}"
           done

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,28 @@ RUN out/dwarfbot --help
 
 # Build the final image
 FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+ARG BUILD_DATE="1970-01-01T00:00:00Z"
+ARG VCS_REF="unknown"
+ARG VERSION="dev"
+
+LABEL org.opencontainers.image.title="dwarfbot" \
+      org.opencontainers.image.description="DwarfBot - a multi-platform chat bot" \
+      org.opencontainers.image.url="https://github.com/clcollins/dwarfbot" \
+      org.opencontainers.image.source="https://github.com/clcollins/dwarfbot" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.vendor="clcollins" \
+      org.opencontainers.image.licenses="MIT" \
+      io.k8s.display-name="dwarfbot" \
+      io.k8s.description="DwarfBot - a multi-platform chat bot" \
+      is.collins.cluster.image.revision="${VCS_REF}" \
+      is.collins.cluster.image.version="${VERSION}" \
+      is.collins.cluster.image.created="${BUILD_DATE}" \
+      is.collins.cluster.build.commit.id="${VCS_REF}" \
+      is.collins.cluster.build.date="${BUILD_DATE}"
+
 COPY --from=builder /opt/app-root/src/out/dwarfbot /dwarfbot
 
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ image-build:
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--build-arg VCS_REF=$(GIT_REF) \
 		--build-arg VERSION=$(VERSION) \
-		-t $(IMAGE_STRING):$(GIT_SHA) \
-		-t $(IMAGE_STRING):latest .
+		-t $(IMAGE_STRING):$(GIT_SHA) -t $(IMAGE_STRING):latest .
 
 .PHONY: image-push
 image-push:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CONTAINER_FILE := Containerfile
 IMAGE_STRING := $(IMAGE_REGISTRY)/$(PROJECT)/$(NAME)
 
 GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-GIT_REF := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION ?= dev
 
@@ -59,7 +59,7 @@ build:
 image-build:
 	$(CONTAINER_SUBSYS) build -f $(CONTAINER_FILE) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
-		--build-arg VCS_REF=$(GIT_REF) \
+		--build-arg VCS_REF=$(GIT_COMMIT) \
 		--build-arg VERSION=$(VERSION) \
 		-t $(IMAGE_STRING):$(GIT_SHA) -t $(IMAGE_STRING):latest .
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ IMAGE_REGISTRY := quay.io
 CONTAINER_FILE := Containerfile
 IMAGE_STRING := $(IMAGE_REGISTRY)/$(PROJECT)/$(NAME)
 
+GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_REF := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION ?= dev
+
 GO := go
 GOFLAGS ?=
 
@@ -52,7 +57,17 @@ build:
 
 .PHONY: image-build
 image-build:
-	$(CONTAINER_SUBSYS) build -f $(CONTAINER_FILE) -t $(IMAGE_STRING):latest .
+	$(CONTAINER_SUBSYS) build -f $(CONTAINER_FILE) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		--build-arg VCS_REF=$(GIT_REF) \
+		--build-arg VERSION=$(VERSION) \
+		-t $(IMAGE_STRING):$(GIT_SHA) \
+		-t $(IMAGE_STRING):latest .
+
+.PHONY: image-push
+image-push:
+	$(CONTAINER_SUBSYS) push $(IMAGE_STRING):$(GIT_SHA)
+	$(CONTAINER_SUBSYS) push $(IMAGE_STRING):latest
 
 # --- Linting tools ---
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ image-build:
 		-t $(IMAGE_STRING):$(GIT_SHA) -t $(IMAGE_STRING):latest .
 
 .PHONY: image-push
-image-push:
+image-push: image-build
 	$(CONTAINER_SUBSYS) push $(IMAGE_STRING):$(GIT_SHA)
 	$(CONTAINER_SUBSYS) push $(IMAGE_STRING):latest
 

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -70,11 +70,11 @@ on:
 
 Tag strategy via `docker/metadata-action`:
 
-| Event | Tags generated |
-|-------|----------------|
-| PR #22 | `pr-22`, `abc1234` (build only) |
-| Push to main | `latest`, `abc1234` |
-| Tag v0.2.0 | `v0.2.0`, `0.2.0`, `abc1234` |
+| Event        | Tags generated                    |
+|--------------|-----------------------------------|
+| PR #22       | `pr-22`, `abc1234` (build only)   |
+| Push to main | `latest`, `abc1234`               |
+| Tag v0.2.0   | `v0.2.0`, `0.2.0`, `abc1234`     |
 
 Push is conditional: `push: ${{ github.event_name != 'pull_request' }}`
 
@@ -127,7 +127,7 @@ actual CI values.
 Reduce build context size and prevent unnecessary files from being
 included:
 
-```
+```text
 .git
 .github
 out/
@@ -170,10 +170,10 @@ metadata, without requiring registry credentials.
 Two repository secrets must be added in GitHub repository settings
 (Settings > Secrets and variables > Actions):
 
-| Secret | Description |
-|--------|-------------|
+| Secret          | Description                    |
+|-----------------|--------------------------------|
 | `QUAY_USERNAME` | Quay.io robot account username |
-| `QUAY_PASSWORD` | Quay.io robot account token |
+| `QUAY_PASSWORD` | Quay.io robot account token    |
 
 Recommendation: Create a Quay.io robot account with push access scoped
 to `clcollins/dwarfbot` only.
@@ -193,12 +193,12 @@ to `clcollins/dwarfbot` only.
 
 ## Risks and Mitigations
 
-| Risk | Mitigation |
-|------|------------|
-| QEMU arm64 emulation is slow (10-20 min) | GHA layer caching; future optimization: Go cross-compilation in builder stage |
-| UBI go-toolset arm64 image might not exist for 1.25 tag | Verify availability; fallback: use `golang:1.25` for builder stage |
-| checkmake rejects Makefile changes | Follow Makefile conventions checkmake expects |
-| `docker/metadata-action` label output conflicts with Containerfile LABELs | `--label` flags from the action override Containerfile defaults (desired behavior) |
+| Risk                                                                       | Mitigation                                                                         |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| QEMU arm64 emulation is slow (10-20 min)                                   | GHA layer caching; future optimization: Go cross-compilation in builder stage      |
+| UBI go-toolset arm64 image might not exist for 1.25 tag                    | Verify availability; fallback: use `golang:1.25` for builder stage                 |
+| checkmake rejects Makefile changes                                         | Follow Makefile conventions checkmake expects                                      |
+| `docker/metadata-action` label output conflicts with Containerfile LABELs  | `--label` flags from the action override Containerfile defaults (desired behavior) |
 
 ## Lessons Learned
 

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -114,9 +114,8 @@ Labels follow:
 ARGs have sensible defaults so local `podman build` still works without
 passing build args.
 
-The `docker/build-push-action` `labels` input from
-`docker/metadata-action` supplements/overrides these at build time with
-actual CI values.
+The `--build-arg` values passed by the CI workflow override these
+defaults at build time with actual CI values.
 
 ### 3. New: `.dockerignore`
 
@@ -194,7 +193,7 @@ to `clcollins/dwarfbot` only.
 | QEMU arm64 emulation is slow (10-20 min)                                   | GHA layer caching; future optimization: Go cross-compilation in builder stage      |
 | UBI go-toolset arm64 image might not exist for 1.25 tag                    | Verify availability; fallback: use `golang:1.25` for builder stage                 |
 | checkmake rejects Makefile changes                                         | Follow Makefile conventions checkmake expects                                      |
-| `docker/metadata-action` label output conflicts with Containerfile LABELs  | `--label` flags from the action override Containerfile defaults (desired behavior) |
+| `--build-arg` values conflict with Containerfile LABEL defaults            | CI build-arg values override Containerfile ARG defaults (desired behavior)         |
 
 ## Lessons Learned
 

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -190,7 +190,7 @@ to `clcollins/dwarfbot` only.
 
 | Risk                                                                       | Mitigation                                                                         |
 |----------------------------------------------------------------------------|------------------------------------------------------------------------------------|
-| QEMU arm64 emulation is slow (10-20 min)                                   | GHA layer caching; future optimization: Go cross-compilation in builder stage      |
+| QEMU arm64 emulation is slow (10-20 min)                                   | No caching currently; future: registry-based caching or Go cross-compilation       |
 | UBI go-toolset arm64 image might not exist for 1.25 tag                    | Verify availability; fallback: use `golang:1.25` for builder stage                 |
 | checkmake rejects Makefile changes                                         | Follow Makefile conventions checkmake expects                                      |
 | `--build-arg` values conflict with Containerfile LABEL defaults            | CI build-arg values override Containerfile ARG defaults (desired behavior)         |

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -74,7 +74,7 @@ Tag strategy via `docker/metadata-action`:
 |--------------|-----------------------------------|
 | PR #22       | `pr-22`, `abc1234` (build only)   |
 | Push to main | `latest`, `abc1234`               |
-| Tag v0.2.0   | `v0.2.0`, `0.2.0`, `abc1234`     |
+| Tag v0.2.0   | `v0.2.0`, `0.2.0`, `abc1234`      |
 
 Push is conditional: `push: ${{ github.event_name != 'pull_request' }}`
 

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -36,9 +36,9 @@ and CI validation.
   extending `ci.yaml`. The existing CI handles code quality; the new
   workflow handles container publishing. Different triggers are needed
   (the new workflow needs `push tags: ['v*']`).
-- **Docker buildx with QEMU** for multi-arch builds. This is the
-  standard GitHub Actions approach for multi-platform manifests.
-  `docker/build-push-action` handles manifest creation automatically.
+- **Podman with QEMU** for multi-arch builds. Podman's `--platform`
+  flag and `podman manifest` handle per-architecture builds and manifest
+  creation natively without Docker dependencies.
 - **Existing `image-build` job in `ci.yaml`** is preserved and enhanced
   with build-arg passing and label validation. It continues to serve as
   a podman-based smoke test.
@@ -47,15 +47,13 @@ and CI validation.
 
 ### 1. New: `.github/workflows/image-build-push.yaml`
 
-Multi-arch build-and-push workflow using:
+Multi-arch build-and-push workflow using Podman:
 
-- `docker/setup-qemu-action@v3` - ARM64 emulation
-- `docker/setup-buildx-action@v3` - buildx builder
-- `docker/login-action@v3` - quay.io authentication (conditional, not
-  on PRs)
-- `docker/metadata-action@v5` - tag and label generation from git
-  context
-- `docker/build-push-action@v6` - multi-platform build and push
+- `qemu-user-static` package for ARM64 emulation
+- `podman login` for quay.io authentication (conditional, not on PRs)
+- Shell-based tag and label generation from git context
+- `podman build --platform` for per-architecture builds
+- `podman manifest` for multi-arch manifest creation and push
 
 Triggers:
 
@@ -68,7 +66,7 @@ on:
     tags: ['v*']
 ```
 
-Tag strategy via `docker/metadata-action`:
+Tag strategy via shell script in metadata step:
 
 | Event        | Tags generated                    |
 |--------------|-----------------------------------|
@@ -76,9 +74,7 @@ Tag strategy via `docker/metadata-action`:
 | Push to main | `latest`, `abc1234`               |
 | Tag v0.2.0   | `v0.2.0`, `0.2.0`, `abc1234`      |
 
-Push is conditional: `push: ${{ github.event_name != 'pull_request' }}`
-
-GHA layer caching: `cache-from: type=gha` / `cache-to: type=gha,mode=max`
+Push is conditional: skipped when `github.event_name == 'pull_request'`
 
 ### 2. Modify: `Containerfile`
 

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -30,7 +30,7 @@ and CI validation.
 5. **Registry:** quay.io/clcollins/dwarfbot with robot account
    credentials via GitHub secrets
 
-## Architecture Decision: Separate Workflow + Docker Buildx
+## Architecture Decision: Separate Workflow + Podman
 
 - **Separate workflow file** (`image-build-push.yaml`) rather than
   extending `ci.yaml`. The existing CI handles code quality; the new
@@ -142,7 +142,7 @@ by both Docker buildx and Podman.
 
 Add git metadata variables and update `image-build` to pass build args:
 
-- New variables: `GIT_SHA`, `GIT_REF`, `BUILD_DATE`, `VERSION`
+- New variables: `GIT_SHA`, `GIT_COMMIT`, `BUILD_DATE`, `VERSION`
 - Updated `image-build` target: passes `--build-arg` for all three ARGs,
   tags with both `$(GIT_SHA)` and `latest`
 - New `image-push` target: pushes tagged images to registry

--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -1,0 +1,205 @@
+# Plan: Container Image Build & Push via GitHub Actions
+
+## Status: Draft
+
+## Objective
+
+Add automated multi-architecture container image builds and pushes to
+quay.io/clcollins/dwarfbot via GitHub Actions, with proper OCI labels
+and CI validation.
+
+## Requirements
+
+1. **Build triggers and tagging:**
+   - Every PR: build only (no push), tagged with short git SHA and
+     `pr-<number>` for validation
+   - Every tagged release (`v*`): build and push, tagged with short git
+     SHA and version (e.g., `dwarfbot:v0.2.0`)
+   - Every merge to `main`: build and push, tagged with short git SHA
+     and `latest`
+
+2. **Multi-architecture:** Build linux/amd64 and linux/arm64 images in a
+   single OCI manifest
+
+3. **OCI/Red Hat labels:** Add standard metadata labels following OCI
+   image-spec and Red Hat conventions
+
+4. **CI validation:** Ensure Containerfile changes continue to produce
+   images with expected labels and a working binary
+
+5. **Registry:** quay.io/clcollins/dwarfbot with robot account
+   credentials via GitHub secrets
+
+## Architecture Decision: Separate Workflow + Docker Buildx
+
+- **Separate workflow file** (`image-build-push.yaml`) rather than
+  extending `ci.yaml`. The existing CI handles code quality; the new
+  workflow handles container publishing. Different triggers are needed
+  (the new workflow needs `push tags: ['v*']`).
+- **Docker buildx with QEMU** for multi-arch builds. This is the
+  standard GitHub Actions approach for multi-platform manifests.
+  `docker/build-push-action` handles manifest creation automatically.
+- **Existing `image-build` job in `ci.yaml`** is preserved and enhanced
+  with build-arg passing and label validation. It continues to serve as
+  a podman-based smoke test.
+
+## Files to Create/Modify
+
+### 1. New: `.github/workflows/image-build-push.yaml`
+
+Multi-arch build-and-push workflow using:
+
+- `docker/setup-qemu-action@v3` - ARM64 emulation
+- `docker/setup-buildx-action@v3` - buildx builder
+- `docker/login-action@v3` - quay.io authentication (conditional, not
+  on PRs)
+- `docker/metadata-action@v5` - tag and label generation from git
+  context
+- `docker/build-push-action@v6` - multi-platform build and push
+
+Triggers:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main]
+    tags: ['v*']
+```
+
+Tag strategy via `docker/metadata-action`:
+
+| Event | Tags generated |
+|-------|----------------|
+| PR #22 | `pr-22`, `abc1234` (build only) |
+| Push to main | `latest`, `abc1234` |
+| Tag v0.2.0 | `v0.2.0`, `0.2.0`, `abc1234` |
+
+Push is conditional: `push: ${{ github.event_name != 'pull_request' }}`
+
+GHA layer caching: `cache-from: type=gha` / `cache-to: type=gha,mode=max`
+
+### 2. Modify: `Containerfile`
+
+Add `ARG` and `LABEL` instructions to the runtime stage:
+
+```dockerfile
+ARG BUILD_DATE="1970-01-01T00:00:00Z"
+ARG VCS_REF="unknown"
+ARG VERSION="dev"
+
+LABEL org.opencontainers.image.title="dwarfbot" \
+      org.opencontainers.image.description="DwarfBot - a multi-platform chat bot" \
+      org.opencontainers.image.url="https://github.com/clcollins/dwarfbot" \
+      org.opencontainers.image.source="https://github.com/clcollins/dwarfbot" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.vendor="clcollins" \
+      org.opencontainers.image.licenses="MIT" \
+      io.k8s.display-name="dwarfbot" \
+      io.k8s.description="DwarfBot - a multi-platform chat bot" \
+      is.collins.cluster.image.revision="${VCS_REF}" \
+      is.collins.cluster.image.version="${VERSION}" \
+      is.collins.cluster.image.created="${BUILD_DATE}" \
+      is.collins.cluster.build.commit.id="${VCS_REF}" \
+      is.collins.cluster.build.date="${BUILD_DATE}"
+```
+
+Labels follow:
+
+- **OCI image-spec** (`org.opencontainers.image.*`): title, description,
+  url, source, revision, version, created, vendor, licenses
+- **Kubernetes** (`io.k8s.*`): display-name, description
+- **Collins cluster** (`is.collins.cluster.image.*`,
+  `is.collins.cluster.build.*`): image metadata and build provenance
+
+ARGs have sensible defaults so local `podman build` still works without
+passing build args.
+
+The `docker/build-push-action` `labels` input from
+`docker/metadata-action` supplements/overrides these at build time with
+actual CI values.
+
+### 3. New: `.dockerignore`
+
+Reduce build context size and prevent unnecessary files from being
+included:
+
+```
+.git
+.github
+out/
+docs/
+img/
+deploy/
+*.md
+LICENSE
+.markdownlint.yaml
+.dwarfbot.yaml
+```
+
+Using `.dockerignore` (not `.containerignore`) because it is recognized
+by both Docker buildx and Podman.
+
+### 4. Modify: `Makefile`
+
+Add git metadata variables and update `image-build` to pass build args:
+
+- New variables: `GIT_SHA`, `GIT_REF`, `BUILD_DATE`, `VERSION`
+- Updated `image-build` target: passes `--build-arg` for all three ARGs,
+  tags with both `$(GIT_SHA)` and `latest`
+- New `image-push` target: pushes tagged images to registry
+
+### 5. Modify: `.github/workflows/ci.yaml`
+
+Enhance the existing `image-build` job to:
+
+- Pass `--build-arg` values to the podman build command
+- Add a "Validate OCI labels" step that inspects the built image and
+  verifies expected labels are present
+- Add a "Validate image runs" step that runs the container and verifies
+  `--help` output
+
+This provides CI validation that Containerfile changes produce correct
+metadata, without requiring registry credentials.
+
+## Secret Configuration
+
+Two repository secrets must be added in GitHub repository settings
+(Settings > Secrets and variables > Actions):
+
+| Secret | Description |
+|--------|-------------|
+| `QUAY_USERNAME` | Quay.io robot account username |
+| `QUAY_PASSWORD` | Quay.io robot account token |
+
+Recommendation: Create a Quay.io robot account with push access scoped
+to `clcollins/dwarfbot` only.
+
+## Implementation Steps
+
+1. Create `.dockerignore`
+2. Modify `Containerfile` to add ARG/LABEL instructions
+3. Update `Makefile` with git metadata variables and build-arg passing
+4. Update `.github/workflows/ci.yaml` to validate labels in image-build
+   job
+5. Create `.github/workflows/image-build-push.yaml`
+6. Run `make ci` to validate all changes
+7. Run `make image-build` to validate local container build
+8. Manual: configure `QUAY_USERNAME` and `QUAY_PASSWORD` secrets in
+   GitHub repo settings
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| QEMU arm64 emulation is slow (10-20 min) | GHA layer caching; future optimization: Go cross-compilation in builder stage |
+| UBI go-toolset arm64 image might not exist for 1.25 tag | Verify availability; fallback: use `golang:1.25` for builder stage |
+| checkmake rejects Makefile changes | Follow Makefile conventions checkmake expects |
+| `docker/metadata-action` label output conflicts with Containerfile LABELs | `--label` flags from the action override Containerfile defaults (desired behavior) |
+
+## Lessons Learned
+
+(To be filled in after implementation)


### PR DESCRIPTION
## Summary

This PR implements automated multi-architecture container image builds and pushes to quay.io via GitHub Actions, with proper OCI metadata labels and CI validation.

## Key Changes

- **New GitHub Actions workflow** (`.github/workflows/image-build-push.yaml`): Automated multi-platform (linux/amd64, linux/arm64) container builds using Podman with QEMU emulation. Triggers on PRs (build-only), pushes to main (build + push with `latest` tag), and version tags (build + push with semver tags).

- **Enhanced Containerfile**: Added ARG and LABEL instructions following OCI image-spec and Red Hat conventions. Labels include standard metadata (title, description, URL, revision, version, created date, vendor, licenses) plus Kubernetes and custom cluster labels. ARGs have sensible defaults for local builds.

- **Updated CI workflow** (`.github/workflows/ci.yaml`): Enhanced `image-build` job to pass build arguments and validate that OCI labels are correctly set in the built image. Added validation step to verify the container runs successfully.

- **Makefile improvements**: Added git metadata variables (`GIT_SHA`, `GIT_COMMIT`, `BUILD_DATE`, `VERSION`) and updated `image-build` target to pass build args and tag with both short SHA and `latest`. Added new `image-push` target for pushing images to registry.

- **New `.dockerignore`**: Reduces build context size by excluding unnecessary files (.git, .github, docs, deploy, markdown files, etc.).

- **Documentation**: Added comprehensive implementation plan (`docs/plan-container-build-push.md`) detailing architecture decisions, requirements, risks, and implementation steps.

## Implementation Details

- **Separate workflow**: Uses dedicated `image-build-push.yaml` rather than extending `ci.yaml` to keep concerns separated (code quality vs. container publishing) and support different triggers.
- **Tag strategy**: PRs get `pr-<number>` and short SHA tags (build-only); main branch gets `latest` and short SHA; version tags get semver variants.
- **Conditional push**: Registry login and push only occur on non-PR events, preventing unnecessary authentication attempts.
- **Label validation**: CI now verifies that critical OCI labels (title, revision, version, commit ID, display-name) are present in built images.
- **Build args**: All three ARGs (BUILD_DATE, VCS_REF, VERSION) have defaults so local `podman build` works without arguments.

## Configuration Required

Two GitHub repository secrets must be configured:
- `QUAY_USERNAME`: Quay.io robot account username
- `QUAY_PASSWORD`: Quay.io robot account token