### PR TITLE
docs: add post-mortem lessons learned from PR reviews

### DIFF
--- a/docs/plan-container-build-push.md
+++ b/docs/plan-container-build-push.md
@@ -195,6 +195,61 @@ to `clcollins/dwarfbot` only.
 | checkmake rejects Makefile changes                                         | Follow Makefile conventions checkmake expects                                      |
 | `--build-arg` values conflict with Containerfile LABEL defaults            | CI build-arg values override Containerfile ARG defaults (desired behavior)         |
 
-## Lessons Learned
+## Lessons Learned (PR #9 Review)
 
-(To be filled in after implementation)
+_Lessons captured from PR #9 Copilot code review and CI
+qualification._
+
+### What Went Well
+
+- Separate workflow file kept CI concerns cleanly separated
+  from container publishing
+- Conditional push (`github.event_name != 'pull_request'`)
+  prevented accidental pushes from PR builds
+- OCI label validation in CI caught label issues early
+
+### What Went Wrong
+
+- **Podman not installed on runner** (Copilot round 1 #1):
+  The workflow used `podman` commands but `ubuntu-latest`
+  does not guarantee Podman is available. Would have failed
+  at the first `podman` invocation. Caught by Copilot
+  review; fixed by adding explicit `apt-get install podman`.
+
+- **Manifest push used wrong object type** (Copilot round 1
+  #3): The manifest push loop used `podman tag` on manifest
+  lists and then pushed each tag separately. `podman tag`
+  operates on images, not manifest lists. Fixed by pushing
+  the source manifest directly to each tag destination.
+
+- **Manifest creation skipped for PRs** (Copilot round 2
+  #1): PR builds skipped manifest creation entirely, meaning
+  multi-arch assembly was never validated on PRs. Fixed by
+  creating the manifest locally for all builds and only
+  skipping the registry push.
+
+- **PR tags never applied locally** (Copilot round 3 #1):
+  Tags like `pr-9` and the short SHA were computed in
+  metadata but never applied to local images during PR
+  builds, making the stated tagging behavior inconsistent
+  with reality. Fixed by applying all computed tags locally.
+
+- **Version label mismatch** (Copilot round 3 #2): When
+  publishing a version tag like `v0.2.0`, the OCI
+  `version` label used `v0.2.0` but the published tag was
+  `0.2.0` (without prefix). Fixed by using the no-`v` form
+  for the version build-arg.
+
+### Lessons Learned
+
+- GitHub-hosted runners may not have all container tools
+  pre-installed — always explicitly install required tools
+- When building multi-arch manifests with Podman, use
+  `containers-storage:` transport to reference locally-built
+  images instead of assuming registry access
+- Multi-arch manifest creation should run on PR builds too
+  (just skip the push) to validate the assembly process
+- Tag metadata computed in one step should be applied in a
+  later step — don't just log what "would be" created
+- Version labels and published tags must use the same format
+  to avoid consumer confusion

--- a/docs/plan-container-non-root.md
+++ b/docs/plan-container-non-root.md
@@ -87,3 +87,30 @@ writes at runtime.
 - Help works: `podman run --read-only --rm dwarfbot:test --help`
 - Local dev with config file unchanged:
   `./out/dwarfbot --config ~/.dwarfbot.yaml`
+
+## Post-Mortem (PR #4 Review)
+
+_Lessons captured from PR #4 Copilot code review._
+
+### What Went Well
+
+- `errors.As()` for `viper.ConfigFileNotFoundError` cleanly
+  distinguished "missing file" from "parse error"
+- Environment variable prefix prevented collisions with
+  other tools' env vars
+
+### What Went Wrong
+
+- **Silent backward-incompatible env var change** (Copilot
+  #1): Adding `viper.SetEnvPrefix("DWARFBOT")` silently
+  broke any existing deployments using unprefixed env vars
+  like `DISCORD_TOKEN`. The plan doc listed the new prefixed
+  names but didn't call out the breaking change or provide
+  migration guidance. Caught by Copilot review.
+
+### Lessons Learned
+
+- Changes to environment variable names are a public API
+  change — document the migration path and consider
+  supporting both old and new names during a transition
+  period via `viper.BindEnv()`

--- a/docs/plan-discord-support.md
+++ b/docs/plan-discord-support.md
@@ -152,3 +152,63 @@ To use the Discord integration:
   operation
 - Manual: Verify admin commands only work for users with
   the configured role
+
+## Post-Mortem (PR #3 Review)
+
+_Lessons captured from PR #3 Copilot code review. Cluster
+deployment verification is separate._
+
+### What Went Well
+
+- ChatPlatform interface cleanly abstracted both platforms
+  with no platform-specific leakage into command handlers
+- Mock platform enabled thorough command testing without
+  real network connections
+- Dual-platform startup logic correctly handled all
+  combinations (both, either, neither)
+
+### What Went Wrong
+
+- **Shutdown no-op in Discord-only mode** (Copilot #1):
+  `DiscordBot.Shutdown()` did nothing when `exitFunc` was nil,
+  meaning the `!dwarfbot shutdown` admin command wouldn't
+  actually stop the bot. Caught by Copilot review; fixed by
+  ensuring `exitFunc` always defaults to `os.Exit`.
+
+- **Data race on adminRoleCache** (Copilot #13): The
+  `adminRoleCache` map was accessed without synchronization.
+  Discord handlers run concurrently, so simultaneous admin
+  checks could panic. Caught by Copilot review.
+
+- **Interface violation after Die() signature change**
+  (Copilot #17): `DwarfBot.Die` was changed to accept an exit
+  code parameter but the `Bot` interface wasn't updated,
+  breaking the interface contract. Caught by Copilot review.
+
+- **Nil conn panic in Disconnect()** (Copilot #37):
+  `Disconnect()` unconditionally called `db.conn.Close()`
+  without nil-checking, causing a panic if called before
+  `Connect()`. Caught by Copilot review.
+
+- **Build failure on clean checkout** (Copilot #21/#22):
+  `go build -o out/dwarfbot` would fail because the `out/`
+  directory didn't exist. Applied to both Makefile and
+  Containerfile. Caught by Copilot review; fixed by adding
+  `mkdir -p out`.
+
+- **Flag type mismatch** (Copilot #20): `channels` defined
+  as `StringP` but read via `viper.GetStringSlice()`. Type
+  mismatch could cause unexpected behavior depending on how
+  the value was provided. Caught by Copilot review.
+
+### Lessons Learned
+
+- Always nil-check `net.Conn` before calling `Close()` —
+  lifecycle ordering isn't guaranteed across all code paths
+- When changing function signatures on concrete types, grep
+  for interface definitions that reference them
+- Maps shared across goroutines need synchronization even if
+  concurrent access seems unlikely — Discord's event handlers
+  run in goroutines by default
+- Build targets that write to directories must create those
+  directories first (`mkdir -p`)

--- a/docs/plan-go-update.md
+++ b/docs/plan-go-update.md
@@ -57,3 +57,25 @@ New indirect dependencies added by viper v1.21.0:
   the available UBI9 go-toolset builder image.
 - UBI 9 (ubi-minimal) replaces UBI 8 as the base container
   image, as UBI 8 is approaching end of maintenance support.
+
+## Post-Mortem (PR #3 Review)
+
+_Lessons captured from PR #3 Copilot code review._
+
+### What Went Wrong
+
+- **Plan doc version mismatch** (Copilot #19/#32): The plan
+  document originally stated Go 1.24 and listed dependency
+  versions that didn't match the actual `go.mod` contents
+  (e.g., viper listed as v1.21.0 but `go.mod` had v1.20.1,
+  locafero listed as v0.6.0→v0.12.0 but actual was v0.7.0).
+  Caught by Copilot review.
+
+### Lessons Learned
+
+- After running `go get -u` and `go mod tidy`, re-read
+  `go.mod` and update the plan's dependency table to match
+  actual resolved versions — don't assume `go get -u` will
+  pull the exact version you expect
+- Plan documents should be updated as a final step after all
+  code changes are committed, not written speculatively

--- a/docs/plan-graceful-shutdown.md
+++ b/docs/plan-graceful-shutdown.md
@@ -43,3 +43,55 @@ metrics server shutdown.
 `ReadLine()` doesn't accept a context. You'd still need to close
 the conn to unblock it. The `Stop()` approach achieves the same
 result with no interface changes and minimal code.
+
+## Post-Mortem (PR #8 Review)
+
+_Lessons captured from PR #8 Copilot code review._
+
+### What Went Well
+
+- `Stop()` + connection close pattern cleanly unblocked
+  `ReadLine()` without needing context plumbing
+- Mutex-protected `stopped` flag prevented race conditions
+  on the shutdown signal itself
+- 5-second shutdown wait in signal handler gave the goroutine
+  time to finish without hanging indefinitely
+
+### What Went Wrong
+
+- **Disconnect reason overwritten during shutdown** (Copilot
+  #1/#2): `Stop()` set `lastDisconnectReason = "shutdown"`,
+  but `HandleChat()` overwrote it with `"read_error"` when
+  the closed connection caused `ReadLine()` to fail. This
+  meant shutdown metrics recorded the wrong disconnect
+  reason. Caught by Copilot review.
+
+- **Conn accessed without mutex** (Copilot #7/#9): `Stop()`
+  reads `db.conn` under `mu`, but `Connect()` and
+  `Disconnect()` read/write `db.conn` without the mutex,
+  creating a data race. Caught by Copilot review.
+
+- **Stop during retry backoff not interruptible** (Copilot
+  #3/#8): If `Stop()` was called during `Connect()`'s retry
+  backoff sleep (up to ~10s), the goroutine wouldn't notice
+  until the sleep completed, exceeding the 5s shutdown
+  window. Should have used a `select` on `time.After()` vs
+  the stop channel. Caught by Copilot review.
+
+- **Missing IRC QUIT message** (Copilot #12): The PR
+  description mentioned sending a QUIT message to IRC on
+  shutdown, but the implementation only closes the connection
+  without writing QUIT. Caught by Copilot review.
+
+### Lessons Learned
+
+- When adding a "reason" field that can be set from multiple
+  code paths, establish precedence rules — shutdown reason
+  should not be overwritable by error-handling paths
+- All reads/writes of shared mutable state (`conn`,
+  `lastDisconnectReason`) must be under the same mutex, not
+  just the flag that gates them
+- Interruptible sleeps require `select` with a stop channel
+  — `time.Sleep()` in a retry loop is not cancellable
+- PR descriptions are reviewed for accuracy — if the
+  description claims a behavior, the code must implement it

--- a/docs/plan-resilience-and-metrics.md
+++ b/docs/plan-resilience-and-metrics.md
@@ -105,3 +105,99 @@ PrometheusRule CR for OpenShift with:
 - Start with only Discord token: Twitch warning, Discord works
 - Start with only Twitch token: Discord warning, Twitch works
 - Start with neither: fatal exit
+
+## Post-Mortem (PR #7 Review)
+
+_Lessons captured from PR #7 Copilot code review and PR #8
+follow-up fix. Cluster deployment verification is separate._
+
+### What Went Well
+
+- PlatformMetrics interface with nil-guard pattern cleanly
+  separated metric recording from platform code
+- Custom prometheus.Registry (not global) enabled isolated
+  testing without metric pollution between tests
+- Resilience logic correctly degraded to single-platform
+  mode when one platform failed
+
+### What Went Wrong
+
+- **PromQL failure ratio wrong** (Copilot #4/#28): The
+  `DwarfBotHighMessageFailureRate` alert had two bugs:
+  (1) the `result` label wasn't aggregated away so the
+  division only matched failure/failure instead of
+  failure/total, and (2) the denominator used `> 0` which
+  produces a boolean (0/1) instead of the actual rate. Both
+  would cause the alert to either never fire or produce
+  `+Inf`. Caught by Copilot review.
+
+- **BotName used as platform label** (Copilot #3):
+  `RecordCommandProcessed` was passed `platform.BotName()`
+  (e.g., "dwarfbot") instead of the platform identifier
+  ("twitch"/"discord"), mislabeling the
+  `dwarfbot_commands_processed_total` metric series. Caught
+  by Copilot review.
+
+- **Unbounded label cardinality** (Copilot #22): Raw user
+  command strings were used as Prometheus label values.
+  Since commands come from user input, this creates unbounded
+  cardinality which can significantly increase Prometheus
+  memory usage. Caught by Copilot review.
+
+- **SLO alerts fire for unconfigured platforms** (Copilot
+  #15/#16): Burn-rate alerts weren't gated on
+  `dwarfbot_platform_configured == 1`, so they would fire
+  continuously for intentionally-unused platforms in
+  single-platform deployments. Caught by Copilot review.
+
+- **Impossible alert condition** (Copilot #17):
+  `DwarfBotTokenMissing` required
+  `token_present == 0 AND configured == 1`, but
+  `configured` is only set to 1 when a token is present,
+  making the condition impossible. Additionally, the alert
+  was listed in the plan doc but never defined in the rules
+  file (Copilot #21/#25/#29). Caught by Copilot review.
+
+- **Connection leak on HandleChat error** (Copilot #20):
+  When `HandleChat()` returned an error, `Start()` looped
+  back to `Connect()` without closing the existing
+  connection, leaking the previous `net.Conn` and leaving
+  `dwarfbot_platform_connected` stuck at 1. Caught by
+  Copilot review.
+
+- **Disconnect not idempotent** (Copilot #23):
+  `Disconnect()` closed the conn but never set
+  `db.conn = nil`, so double-calling it produced
+  double-close errors and duplicate disconnect metrics.
+  Caught by Copilot review.
+
+- **Invalid Go syntax** (Copilot #1):
+  `for attempt := range maxRetries` doesn't compile in Go
+  (range can't iterate over an int). Should have been a
+  conventional counted loop. Caught by Copilot review.
+
+- **No Twitch graceful shutdown** (Copilot #30, fixed in
+  PR #8): The Twitch bot goroutine had no coordinated
+  shutdown path — SIGINT/SIGTERM killed the process without
+  running deferred `Disconnect()` or recording shutdown
+  metrics. This was significant enough to warrant a
+  follow-up PR (#8) implementing `Stop()`.
+
+### Lessons Learned
+
+- PromQL vector matching is label-aware by default — always
+  verify that numerator and denominator have compatible label
+  sets by using `sum by(...)` or `without(...)` on both sides
+- Never use raw user input as Prometheus label values —
+  normalize to a fixed, low-cardinality set
+- Alert rules for optional components must be gated on a
+  "component enabled" signal to avoid false-positive alerts
+  in partial deployments
+- Validate alert conditions are satisfiable: if the
+  prerequisite for label A being 1 also forces label B to be
+  non-zero, the combined condition is tautological or
+  impossible
+- `Disconnect()` must be idempotent — set `conn = nil` after
+  closing to prevent double-close errors
+- Plan docs that list alert names must match the actual rules
+  file — treat the rules YAML as the source of truth


### PR DESCRIPTION
## Summary

- First post-mortem review across all merged PRs (#3 through #9)
- Classified 95 Copilot review comments from 7 merged PRs
- Identified 29 genuine errors, added lessons learned to 6 plan documents
- PRs #5 (CI fix) and #6 (README update) had no associated plans

## Plans Updated

| Plan | PR | Genuine Errors | Key Findings |
|------|----|----------------|--------------|
| `plan-discord-support.md` | #3 | 7 | Nil conn panic, interface violation, data race on cache map, build dir missing |
| `plan-go-update.md` | #3 | 2 | Plan doc version table didn't match actual go.mod |
| `plan-resilience-and-metrics.md` | #7 | 10 | PromQL vector matching bugs, unbounded label cardinality, impossible alert condition, conn leak |
| `plan-graceful-shutdown.md` | #8 | 4 | Disconnect reason overwritten, conn accessed without mutex, non-interruptible backoff |
| `plan-container-non-root.md` | #4 | 1 | Silent backward-incompatible env var prefix change |
| `plan-container-build-push.md` | #9 | 5 | Podman not installed, manifest push wrong object type, PR tags never applied |

## Classification Criteria

- **Genuine errors** (included): Bugs that would cause runtime failures, incorrect behavior, or data issues
- **Best practices** (excluded): Security hardening, style improvements, defensive coding suggestions
- **Already fixed** (noted only if pattern): Issues caught and fixed within the same PR

## Test plan

- [ ] Verify all markdownlint checks pass
- [ ] Verify no existing plan content was overwritten (only appended)
- [ ] Spot-check lesson attributions match actual Copilot comment content

🤖 Generated with [Claude Code](https://claude.com/claude-code)