### PR TITLE
Use Quay.io robot account for image push auth

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request'
         run: |
-          echo "${{ secrets.QUAY_ROBOT_TOKEN }}" | podman login quay.io \
+          echo "${{ secrets.QUAY_ROBOT_TOKEN }}" | podman login ${{ env.REGISTRY }} \
             --username "${{ secrets.QUAY_ROBOT_USERNAME }}" \
             --password-stdin
 
@@ -102,7 +102,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "Pull request build - manifest created locally; skipping registry push."
             echo "Tags that would be pushed: ${TAGS}"
-            podman manifest inspect "${FULL_IMAGE}:${SHORT_SHA}" || true
+            podman manifest inspect "${FULL_IMAGE}:${SHORT_SHA}"
             exit 0
           fi
 

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -64,8 +64,8 @@ jobs:
       - name: Log in to Quay.io
         if: github.event_name != 'pull_request'
         run: |
-          echo "${{ secrets.QUAY_PASSWORD }}" | podman login quay.io \
-            --username "${{ secrets.QUAY_USERNAME }}" \
+          echo "${{ secrets.QUAY_ROBOT_TOKEN }}" | podman login quay.io \
+            --username "${{ secrets.QUAY_ROBOT_USERNAME }}" \
             --password-stdin
 
       - name: Build linux/amd64 image
@@ -98,13 +98,6 @@ jobs:
             "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-amd64"
           podman manifest add "${FULL_IMAGE}:${SHORT_SHA}" \
             "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64"
-
-          # Apply all computed tags locally
-          for TAG in ${TAGS}; do
-            if [ "${TAG}" != "${FULL_IMAGE}:${SHORT_SHA}" ]; then
-              podman tag "${FULL_IMAGE}:${SHORT_SHA}" "${TAG}"
-            fi
-          done
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "Pull request build - manifest created and tagged locally; skipping registry push."

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -100,9 +100,9 @@ jobs:
             "containers-storage:${FULL_IMAGE}:${SHORT_SHA}-arm64"
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Pull request build - manifest created and tagged locally; skipping registry push."
-            echo "Local tags applied: ${TAGS}"
-            podman images --filter "reference=${FULL_IMAGE}" --format "{{.Repository}}:{{.Tag}}"
+            echo "Pull request build - manifest created locally; skipping registry push."
+            echo "Tags that would be pushed: ${TAGS}"
+            podman manifest inspect "${FULL_IMAGE}:${SHORT_SHA}" || true
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- Switch image push workflow from personal `QUAY_USERNAME`/`QUAY_PASSWORD` secrets to robot account `QUAY_ROBOT_USERNAME`/`QUAY_ROBOT_TOKEN`
- Remove dead `podman tag` loop that tagged images (not manifests) and was never used by the push step

## Test plan
- [ ] Verify `QUAY_ROBOT_USERNAME` and `QUAY_ROBOT_TOKEN` secrets are set in repo settings
- [ ] Merge and confirm push to main triggers a successful image build and push to `quay.io/clcollins/dwarfbot:latest`
- [ ] Tag a release and confirm multi-tag push works (sha, v-prefixed, bare version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)