### PR TITLE
Standardize Twitch config keys to DWARFBOT_TWITCH_* naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export DWARFBOT_TWITCH_CHANNELS=mychannel
 
 # Run with Discord only
 export DWARFBOT_NAME=mybot
-export DWARFBOT_DISCORD_TOKEN=Bot_token_here
+export DWARFBOT_DISCORD_TOKEN=discord_token_here
 export DWARFBOT_DISCORD_CHANNELS=123456789
 ./out/dwarfbot
 
@@ -64,7 +64,7 @@ export DWARFBOT_DISCORD_CHANNELS=123456789
 export DWARFBOT_NAME=mybot
 export DWARFBOT_TWITCH_TOKEN=oauth:abc123
 export DWARFBOT_TWITCH_CHANNELS=mychannel
-export DWARFBOT_DISCORD_TOKEN=Bot_token_here
+export DWARFBOT_DISCORD_TOKEN=discord_token_here
 export DWARFBOT_DISCORD_CHANNELS=123456789
 ./out/dwarfbot
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,61 @@ The cheerful sidekick from
 [https://twitch.tv/hammerdwarf](https://twitch.tv/hammerdwarf),
 and Co.
 
+## Configuration
+
+DwarfBot supports configuration via CLI flags, environment variables
+(`DWARFBOT_` prefix), or a YAML config file (`~/.dwarfbot.yaml`).
+At least one platform (Twitch or Discord) must be configured.
+
+### General Settings
+
+| Config Key | CLI Flag | Env Var | Default | Description |
+| --- | --- | --- | --- | --- |
+| `name` | `--name` / `-n` | `DWARFBOT_NAME` | | Bot display name (used by both platforms) |
+| `verbose` | `--verbose` / `-v` | `DWARFBOT_VERBOSE` | `false` | Enable verbose logging |
+| `metrics_port` | `--metrics-port` | `DWARFBOT_METRICS_PORT` | `8080` | Port for Prometheus metrics and `/healthz` endpoint |
+
+### Twitch Settings
+
+| Config Key | CLI Flag | Env Var | Default | Description |
+| --- | --- | --- | --- | --- |
+| `twitch_token` | `--twitch-token` | `DWARFBOT_TWITCH_TOKEN` | | Twitch OAuth token |
+| `twitch_channels` | `--twitch-channels` | `DWARFBOT_TWITCH_CHANNELS` | | Twitch channels to join |
+| `twitch_server` | `--twitch-server` | `DWARFBOT_TWITCH_SERVER` | `irc.chat.twitch.tv` | Twitch IRC server |
+| `twitch_port` | `--twitch-port` | `DWARFBOT_TWITCH_PORT` | `6667` | Twitch IRC port |
+
+### Discord Settings
+
+| Config Key | CLI Flag | Env Var | Default | Description |
+| --- | --- | --- | --- | --- |
+| `discord_token` | `--discord-token` | `DWARFBOT_DISCORD_TOKEN` | | Discord bot token |
+| `discord_channels` | `--discord-channels` | `DWARFBOT_DISCORD_CHANNELS` | | Discord channel IDs to listen in |
+| `discord_admin_role` | `--discord-admin-role` | `DWARFBOT_DISCORD_ADMIN_ROLE` | `dwarfbot-admin` | Discord role name for admin commands |
+
+### Example
+
+```sh
+# Run with Twitch only
+export DWARFBOT_NAME=mybot
+export DWARFBOT_TWITCH_TOKEN=oauth:abc123
+export DWARFBOT_TWITCH_CHANNELS=mychannel
+./dwarfbot
+
+# Run with Discord only
+export DWARFBOT_NAME=mybot
+export DWARFBOT_DISCORD_TOKEN=Bot_token_here
+export DWARFBOT_DISCORD_CHANNELS=123456789
+./dwarfbot
+
+# Run with both platforms
+export DWARFBOT_NAME=mybot
+export DWARFBOT_TWITCH_TOKEN=oauth:abc123
+export DWARFBOT_TWITCH_CHANNELS=mychannel
+export DWARFBOT_DISCORD_TOKEN=Bot_token_here
+export DWARFBOT_DISCORD_CHANNELS=123456789
+./dwarfbot
+```
+
 ## Acknowledgements
 
 1. dwarfbot is (at least in some part) based on work from

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ DwarfBot supports configuration via CLI flags, environment variables
 (`DWARFBOT_` prefix), or a YAML config file (`~/.dwarfbot.yaml`).
 At least one platform (Twitch or Discord) must be configured.
 
+Note: Some older documents under `docs/` (for example,
+`docs/plan-discord-support.md`) describe legacy configuration keys and
+environment variables. Those documents are kept for historical context
+only and do not reflect the current configuration interface; the tables
+below are the authoritative reference.
+
 ### General Settings
 
 | Config Key | CLI Flag | Env Var | Default | Description |

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ below are the authoritative reference.
 export DWARFBOT_NAME=mybot
 export DWARFBOT_TWITCH_TOKEN=oauth:abc123
 export DWARFBOT_TWITCH_CHANNELS=mychannel
-./dwarfbot
+./out/dwarfbot
 
 # Run with Discord only
 export DWARFBOT_NAME=mybot
 export DWARFBOT_DISCORD_TOKEN=Bot_token_here
 export DWARFBOT_DISCORD_CHANNELS=123456789
-./dwarfbot
+./out/dwarfbot
 
 # Run with both platforms
 export DWARFBOT_NAME=mybot
@@ -66,7 +66,7 @@ export DWARFBOT_TWITCH_TOKEN=oauth:abc123
 export DWARFBOT_TWITCH_CHANNELS=mychannel
 export DWARFBOT_DISCORD_TOKEN=Bot_token_here
 export DWARFBOT_DISCORD_CHANNELS=123456789
-./dwarfbot
+./out/dwarfbot
 ```
 
 ## Acknowledgements

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,10 +63,10 @@ var rootCmd = &cobra.Command{
 		metricsPort := viper.GetString("metrics_port")
 
 		// Twitch config
-		twitchToken := viper.GetString("token")
-		twitchChannels := viper.GetStringSlice("channels")
-		server := viper.GetString("server")
-		port := viper.GetString("port")
+		twitchToken := viper.GetString("twitch_token")
+		twitchChannels := viper.GetStringSlice("twitch_channels")
+		server := viper.GetString("twitch_server")
+		port := viper.GetString("twitch_port")
 
 		// Discord config
 		discordToken := viper.GetString("discord_token")
@@ -77,7 +77,7 @@ var rootCmd = &cobra.Command{
 		discordEnabled := discordToken != "" && len(discordChannels) > 0
 
 		if !twitchEnabled && !discordEnabled {
-			log.Fatal("At least one platform must be configured (Twitch: token + channels, Discord: discord_token + discord_channels)")
+			log.Fatal("At least one platform must be configured (Twitch: twitch_token + twitch_channels, Discord: discord_token + discord_channels)")
 		}
 
 		// Initialize metrics
@@ -202,14 +202,17 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dwarfbot.yaml)")
 
 	// Twitch configuration
-	rootCmd.PersistentFlags().StringP("server", "s", twitchChatServer, fmt.Sprintf("Twitch IRC server (default: %s)", twitchChatServer))
-	cobra.CheckErr(viper.BindPFlag("server", rootCmd.PersistentFlags().Lookup("server")))
+	rootCmd.PersistentFlags().String("twitch-token", "", "Twitch OAuth token")
+	cobra.CheckErr(viper.BindPFlag("twitch_token", rootCmd.PersistentFlags().Lookup("twitch-token")))
 
-	rootCmd.PersistentFlags().StringP("port", "p", twitchChatPort, fmt.Sprintf("Twitch IRC port (default: %s)", twitchChatPort))
-	cobra.CheckErr(viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")))
+	rootCmd.PersistentFlags().String("twitch-server", twitchChatServer, fmt.Sprintf("Twitch IRC server (default: %s)", twitchChatServer))
+	cobra.CheckErr(viper.BindPFlag("twitch_server", rootCmd.PersistentFlags().Lookup("twitch-server")))
 
-	rootCmd.PersistentFlags().StringSliceP("channels", "c", []string{}, "Twitch channels to participate in")
-	cobra.CheckErr(viper.BindPFlag("channels", rootCmd.PersistentFlags().Lookup("channels")))
+	rootCmd.PersistentFlags().String("twitch-port", twitchChatPort, fmt.Sprintf("Twitch IRC port (default: %s)", twitchChatPort))
+	cobra.CheckErr(viper.BindPFlag("twitch_port", rootCmd.PersistentFlags().Lookup("twitch-port")))
+
+	rootCmd.PersistentFlags().StringSlice("twitch-channels", []string{}, "Twitch channels to participate in")
+	cobra.CheckErr(viper.BindPFlag("twitch_channels", rootCmd.PersistentFlags().Lookup("twitch-channels")))
 
 	// General configuration
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable verbose logging")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ var rootCmd = &cobra.Command{
 		discordEnabled := discordToken != "" && len(discordChannels) > 0
 
 		if !twitchEnabled && !discordEnabled {
-			log.Fatal("At least one platform must be configured (Twitch: twitch_token + twitch_channels, Discord: discord_token + discord_channels)")
+			log.Fatal("At least one platform must be configured. Twitch: provide --twitch-token and --twitch-channels (or DWARFBOT_TWITCH_TOKEN and DWARFBOT_TWITCH_CHANNELS). Discord: provide --discord-token and --discord-channels (or DWARFBOT_DISCORD_TOKEN and DWARFBOT_DISCORD_CHANNELS).")
 		}
 
 		// Initialize metrics

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -264,9 +264,9 @@ func TestFlagsHaveUsageText(t *testing.T) {
 	}
 }
 
-// TestConfigKeyNamingConvention validates that all non-general flags follow
-// the DWARFBOT_<PROVIDER>_<ITEM> naming convention (provider-prefixed).
-func TestConfigKeyNamingConvention(t *testing.T) {
+// TestFlagNamingConvention validates that all non-general CLI flags follow
+// the <provider>-<item> naming convention (provider-prefixed).
+func TestFlagNamingConvention(t *testing.T) {
 	generalFlags := map[string]bool{
 		"config":       true,
 		"verbose":      true,
@@ -287,7 +287,7 @@ func TestConfigKeyNamingConvention(t *testing.T) {
 			}
 		}
 		if !hasPrefix {
-			t.Errorf("flag %q does not follow <provider>-<item> naming convention (expected prefix: %v)", f.Name, providerPrefixes)
+			t.Errorf("CLI flag %q does not follow <provider>-<item> naming convention (expected prefix: %v)", f.Name, providerPrefixes)
 		}
 	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -62,7 +62,7 @@ func TestRootCommandHasFlags(t *testing.T) {
 			if flag == nil {
 				t.Fatalf("expected flag %q to exist", f.name)
 			}
-			if f.shorthand != "" && flag.Shorthand != f.shorthand {
+			if flag.Shorthand != f.shorthand {
 				t.Errorf("expected shorthand %q, got %q", f.shorthand, flag.Shorthand)
 			}
 		})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -42,9 +44,10 @@ func TestRootCommandHasFlags(t *testing.T) {
 		shorthand string
 	}{
 		{"config", ""},
-		{"server", "s"},
-		{"port", "p"},
-		{"channels", "c"},
+		{"twitch-token", ""},
+		{"twitch-server", ""},
+		{"twitch-port", ""},
+		{"twitch-channels", ""},
 		{"verbose", "v"},
 		{"name", "n"},
 		{"discord-token", ""},
@@ -75,20 +78,30 @@ func TestDefaultServerAndPort(t *testing.T) {
 	}
 }
 
-func TestServerFlagDefault(t *testing.T) {
-	flag := rootCmd.PersistentFlags().Lookup("server")
+func TestTwitchTokenFlagDefault(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("twitch-token")
 	if flag == nil {
-		t.Fatal("server flag not found")
+		t.Fatal("twitch-token flag not found")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected empty twitch-token default, got %q", flag.DefValue)
+	}
+}
+
+func TestTwitchServerFlagDefault(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("twitch-server")
+	if flag == nil {
+		t.Fatal("twitch-server flag not found")
 	}
 	if flag.DefValue != twitchChatServer {
 		t.Errorf("expected server default %q, got %q", twitchChatServer, flag.DefValue)
 	}
 }
 
-func TestPortFlagDefault(t *testing.T) {
-	flag := rootCmd.PersistentFlags().Lookup("port")
+func TestTwitchPortFlagDefault(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("twitch-port")
 	if flag == nil {
-		t.Fatal("port flag not found")
+		t.Fatal("twitch-port flag not found")
 	}
 	if flag.DefValue != twitchChatPort {
 		t.Errorf("expected port default %q, got %q", twitchChatPort, flag.DefValue)
@@ -115,13 +128,13 @@ func TestNameFlagDefault(t *testing.T) {
 	}
 }
 
-func TestChannelsFlagDefault(t *testing.T) {
-	flag := rootCmd.PersistentFlags().Lookup("channels")
+func TestTwitchChannelsFlagDefault(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("twitch-channels")
 	if flag == nil {
-		t.Fatal("channels flag not found")
+		t.Fatal("twitch-channels flag not found")
 	}
 	if flag.DefValue != "[]" {
-		t.Errorf("expected '[]' channels default, got %q", flag.DefValue)
+		t.Errorf("expected '[]' twitch-channels default, got %q", flag.DefValue)
 	}
 }
 
@@ -195,7 +208,7 @@ func TestInitConfig_NoConfigFile(t *testing.T) {
 func TestInitConfig_EnvVarPrefix(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("DWARFBOT_NAME", "envbot")
-	t.Setenv("DWARFBOT_TOKEN", "env-test-token")
+	t.Setenv("DWARFBOT_TWITCH_TOKEN", "env-test-token")
 	savedCfgFile := cfgFile
 	cfgFile = ""
 	defer func() { cfgFile = savedCfgFile }()
@@ -206,8 +219,8 @@ func TestInitConfig_EnvVarPrefix(t *testing.T) {
 	if got := viper.GetString("name"); got != "envbot" {
 		t.Errorf("expected DWARFBOT_NAME to set name='envbot', got %q", got)
 	}
-	if got := viper.GetString("token"); got != "env-test-token" {
-		t.Errorf("expected DWARFBOT_TOKEN to set token='env-test-token', got %q", got)
+	if got := viper.GetString("twitch_token"); got != "env-test-token" {
+		t.Errorf("expected DWARFBOT_TWITCH_TOKEN to set twitch_token='env-test-token', got %q", got)
 	}
 }
 
@@ -234,7 +247,8 @@ func TestInitConfig_DiscordEnvVars(t *testing.T) {
 
 func TestFlagsHaveUsageText(t *testing.T) {
 	flagNames := []string{
-		"server", "port", "channels", "verbose", "name",
+		"twitch-token", "twitch-server", "twitch-port", "twitch-channels",
+		"verbose", "name",
 		"discord-token", "discord-channels", "discord-admin-role",
 	}
 	for _, name := range flagNames {
@@ -248,4 +262,32 @@ func TestFlagsHaveUsageText(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfigKeyNamingConvention validates that all non-general flags follow
+// the DWARFBOT_<PROVIDER>_<ITEM> naming convention (provider-prefixed).
+func TestConfigKeyNamingConvention(t *testing.T) {
+	generalFlags := map[string]bool{
+		"config":       true,
+		"verbose":      true,
+		"name":         true,
+		"metrics-port": true,
+	}
+	providerPrefixes := []string{"twitch-", "discord-"}
+
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if generalFlags[f.Name] {
+			return
+		}
+		hasPrefix := false
+		for _, p := range providerPrefixes {
+			if strings.HasPrefix(f.Name, p) {
+				hasPrefix = true
+				break
+			}
+		}
+		if !hasPrefix {
+			t.Errorf("flag %q does not follow <provider>-<item> naming convention (expected prefix: %v)", f.Name, providerPrefixes)
+		}
+	})
 }

--- a/docs/plan-container-non-root.md
+++ b/docs/plan-container-non-root.md
@@ -85,8 +85,15 @@ writes at runtime.
 - `make ci` passes all tests
 - Container builds: `podman build -f Containerfile -t dwarfbot:test .`
 - Read-only filesystem works:
-  `podman run --read-only --rm -e DWARFBOT_DISCORD_TOKEN=fake
-  -e DWARFBOT_DISCORD_CHANNELS=123 -e DWARFBOT_NAME=testbot dwarfbot:test`
+
+  ```sh
+  podman run --read-only --rm \
+    -e DWARFBOT_DISCORD_TOKEN=fake \
+    -e DWARFBOT_DISCORD_CHANNELS=123 \
+    -e DWARFBOT_NAME=testbot \
+    dwarfbot:test
+  ```
+
 - Help works: `podman run --read-only --rm dwarfbot:test --help`
 - Local dev with config file unchanged:
   `./out/dwarfbot --config ~/.dwarfbot.yaml`

--- a/docs/plan-container-non-root.md
+++ b/docs/plan-container-non-root.md
@@ -95,7 +95,8 @@ writes at runtime.
   ```
 
 - Help works: `podman run --read-only --rm dwarfbot:test --help`
-- Local dev with config file unchanged:
+- Local dev with migrated config file (`~/.dwarfbot.yaml`); see
+  `docs/plan-standardize-config-keys.md` for migration steps:
   `./out/dwarfbot --config ~/.dwarfbot.yaml`
 
 ## Post-Mortem (PR #4 Review)

--- a/docs/plan-container-non-root.md
+++ b/docs/plan-container-non-root.md
@@ -76,7 +76,7 @@ writes at runtime.
 - `TestInitConfig_NoConfigFile`: Verifies graceful fallback when
   no config file exists
 - `TestInitConfig_EnvVarPrefix`: Verifies `DWARFBOT_NAME` and
-  `DWARFBOT_TOKEN` env vars are read correctly
+  `DWARFBOT_TWITCH_TOKEN` env vars are read correctly
 - `TestInitConfig_DiscordEnvVars`: Verifies Discord-specific
   env vars (`DWARFBOT_DISCORD_TOKEN`, etc.)
 

--- a/docs/plan-container-non-root.md
+++ b/docs/plan-container-non-root.md
@@ -38,14 +38,18 @@ distinguish "not found" from "parse error".
 Added `viper.SetEnvPrefix("DWARFBOT")` so environment variables
 use the `DWARFBOT_` prefix:
 
+_Updated: Config keys renamed for provider-prefix standardization.
+See `docs/plan-standardize-config-keys.md` for details._
+
 | Config Key | CLI Flag | Env Var |
 | --- | --- | --- |
 | `name` | `--name` | `DWARFBOT_NAME` |
-| `token` | _(config/env only)_ | `DWARFBOT_TOKEN` |
-| `channels` | `--channels` | `DWARFBOT_CHANNELS` |
-| `server` | `--server` | `DWARFBOT_SERVER` |
-| `port` | `--port` | `DWARFBOT_PORT` |
+| `twitch_token` | `--twitch-token` | `DWARFBOT_TWITCH_TOKEN` |
+| `twitch_channels` | `--twitch-channels` | `DWARFBOT_TWITCH_CHANNELS` |
+| `twitch_server` | `--twitch-server` | `DWARFBOT_TWITCH_SERVER` |
+| `twitch_port` | `--twitch-port` | `DWARFBOT_TWITCH_PORT` |
 | `verbose` | `--verbose` | `DWARFBOT_VERBOSE` |
+| `metrics_port` | `--metrics-port` | `DWARFBOT_METRICS_PORT` |
 | `discord_token` | `--discord-token` | `DWARFBOT_DISCORD_TOKEN` |
 | `discord_channels` | `--discord-channels` | `DWARFBOT_DISCORD_CHANNELS` |
 | `discord_admin_role` | `--discord-admin-role` | `DWARFBOT_DISCORD_ADMIN_ROLE` |
@@ -82,8 +86,7 @@ writes at runtime.
 - Container builds: `podman build -f Containerfile -t dwarfbot:test .`
 - Read-only filesystem works:
   `podman run --read-only --rm -e DWARFBOT_DISCORD_TOKEN=fake
-  -e DWARFBOT_DISCORD_CHANNELS=123 -e DWARFBOT_NAME=testbot
-  dwarfbot:test`
+  -e DWARFBOT_DISCORD_CHANNELS=123 -e DWARFBOT_NAME=testbot dwarfbot:test`
 - Help works: `podman run --read-only --rm dwarfbot:test --help`
 - Local dev with config file unchanged:
   `./out/dwarfbot --config ~/.dwarfbot.yaml`

--- a/docs/plan-standardize-config-keys.md
+++ b/docs/plan-standardize-config-keys.md
@@ -57,6 +57,7 @@ naming convention regressions.
 ### 1. Flag registration and viper bindings (`cmd/root.go`)
 
 Renamed Twitch flag definitions in `init()`:
+
 - `--server` / `-s` -> `--twitch-server` (no short flag)
 - `--port` / `-p` -> `--twitch-port` (no short flag)
 - `--channels` / `-c` -> `--twitch-channels` (no short flag)
@@ -67,6 +68,7 @@ Updated `viper.BindPFlag()` keys to match.
 ### 2. Viper Get calls (`cmd/root.go`)
 
 Updated `Run` function to use new config key names:
+
 - `viper.GetString("token")` -> `viper.GetString("twitch_token")`
 - `viper.GetStringSlice("channels")` -> `viper.GetStringSlice("twitch_channels")`
 - `viper.GetString("server")` -> `viper.GetString("twitch_server")`
@@ -110,6 +112,7 @@ referencing this plan document.
 ## Migration Guide
 
 Update environment variables:
+
 ```sh
 # Before
 export DWARFBOT_TOKEN=oauth:abc123
@@ -125,6 +128,7 @@ export DWARFBOT_TWITCH_PORT=6667
 ```
 
 Update config file (`~/.dwarfbot.yaml`):
+
 ```yaml
 # Before
 token: oauth:abc123

--- a/docs/plan-standardize-config-keys.md
+++ b/docs/plan-standardize-config-keys.md
@@ -85,11 +85,12 @@ Updated `Run` function to use new config key names:
 
 ### 4. CI naming convention test (`cmd/root_test.go`)
 
-Added `TestConfigKeyNamingConvention` that validates all non-general
-flags follow the `<provider>-<item>` naming convention. General
-flags (`config`, `verbose`, `name`, `metrics-port`) are exempted.
-All other flags must start with a known provider prefix (`twitch-`
-or `discord-`). Runs as part of `make ci` via `go test`.
+Added `TestFlagNamingConvention` that validates all non-general
+CLI flags follow the `<provider>-<item>` naming convention.
+General flags (`config`, `verbose`, `name`, `metrics-port`) are
+exempted. All other flags must start with a known provider prefix
+(`twitch-` or `discord-`). Runs as part of `make ci` via
+`go test`.
 
 ### 5. Prior plan doc updated (`docs/plan-container-non-root.md`)
 
@@ -144,7 +145,7 @@ twitch_channels:
 ## Verification
 
 - `make ci` passes (fmt, vet, test, build)
-- `TestConfigKeyNamingConvention` catches non-compliant flags
+- `TestFlagNamingConvention` catches non-compliant flags
 - Existing tests updated and passing with new key names
 
 ## Post-Mortem

--- a/docs/plan-standardize-config-keys.md
+++ b/docs/plan-standardize-config-keys.md
@@ -1,0 +1,154 @@
+# Plan: Standardize Config Key Naming Convention
+
+## Context
+
+Twitch-related config keys (`token`, `channels`, `server`, `port`)
+lacked a provider prefix, while Discord keys already followed the
+`DWARFBOT_DISCORD_<ITEM>` pattern. This inconsistency made it
+unclear which platform a setting belonged to. This change renames
+all Twitch-specific keys to follow the standard
+`DWARFBOT_<PROVIDER>_<ITEM>` format and adds a CI test to prevent
+naming convention regressions.
+
+## Lessons from Prior Plans
+
+- **plan-container-non-root.md**: Adding `viper.SetEnvPrefix("DWARFBOT")`
+  silently broke unprefixed env vars. This time the breaking change
+  is intentional and documented (clean break, no backward compat).
+- **plan-discord-support.md**: Always check interface definitions
+  when changing signatures. Not applicable here (no interface changes).
+
+## Rename Mapping
+
+| Old Config Key | New Config Key | Old CLI Flag | New CLI Flag | Old Env Var | New Env Var |
+| --- | --- | --- | --- | --- | --- |
+| `token` | `twitch_token` | _(none)_ | `--twitch-token` | `DWARFBOT_TOKEN` | `DWARFBOT_TWITCH_TOKEN` |
+| `channels` | `twitch_channels` | `--channels` / `-c` | `--twitch-channels` | `DWARFBOT_CHANNELS` | `DWARFBOT_TWITCH_CHANNELS` |
+| `server` | `twitch_server` | `--server` / `-s` | `--twitch-server` | `DWARFBOT_SERVER` | `DWARFBOT_TWITCH_SERVER` |
+| `port` | `twitch_port` | `--port` / `-p` | `--twitch-port` | `DWARFBOT_PORT` | `DWARFBOT_TWITCH_PORT` |
+
+### Unchanged (general/cross-cutting settings)
+
+- `name` / `--name` / `-n` / `DWARFBOT_NAME` (used by both platforms)
+- `verbose` / `--verbose` / `-v` / `DWARFBOT_VERBOSE`
+- `metrics_port` / `--metrics-port` / `DWARFBOT_METRICS_PORT`
+
+### Already standard (no changes)
+
+- `discord_token` / `--discord-token` / `DWARFBOT_DISCORD_TOKEN`
+- `discord_channels` / `--discord-channels` / `DWARFBOT_DISCORD_CHANNELS`
+- `discord_admin_role` / `--discord-admin-role` / `DWARFBOT_DISCORD_ADMIN_ROLE`
+
+## Design Decisions
+
+1. **`name` stays general**: The bot display name is shared across
+   both Twitch and Discord platforms.
+2. **Clean break, no backward compat**: Old env var names stop
+   working immediately. No `viper.BindEnv()` fallback.
+3. **Short flags removed** for renamed flags (`-s`, `-p`, `-c`):
+   ambiguous when combined with provider prefix. `-v` (verbose) and
+   `-n` (name) are unchanged general flags and keep their shorthand.
+4. **Added `--twitch-token` CLI flag**: Previously token had no CLI
+   flag (env/config only), but `--discord-token` exists, so added
+   for consistency.
+
+## Changes Made
+
+### 1. Flag registration and viper bindings (`cmd/root.go`)
+
+Renamed Twitch flag definitions in `init()`:
+- `--server` / `-s` -> `--twitch-server` (no short flag)
+- `--port` / `-p` -> `--twitch-port` (no short flag)
+- `--channels` / `-c` -> `--twitch-channels` (no short flag)
+- Added `--twitch-token` (new flag)
+
+Updated `viper.BindPFlag()` keys to match.
+
+### 2. Viper Get calls (`cmd/root.go`)
+
+Updated `Run` function to use new config key names:
+- `viper.GetString("token")` -> `viper.GetString("twitch_token")`
+- `viper.GetStringSlice("channels")` -> `viper.GetStringSlice("twitch_channels")`
+- `viper.GetString("server")` -> `viper.GetString("twitch_server")`
+- `viper.GetString("port")` -> `viper.GetString("twitch_port")`
+
+### 3. Tests updated (`cmd/root_test.go`)
+
+- Flag name table updated with new names and removed short flags
+- Individual default tests renamed (e.g., `TestServerFlagDefault`
+  -> `TestTwitchServerFlagDefault`)
+- Added `TestTwitchTokenFlagDefault`
+- Env var prefix test updated to use `DWARFBOT_TWITCH_TOKEN`
+- Flag usage text test updated with new flag names
+
+### 4. CI naming convention test (`cmd/root_test.go`)
+
+Added `TestConfigKeyNamingConvention` that validates all non-general
+flags follow the `<provider>-<item>` naming convention. General
+flags (`config`, `verbose`, `name`, `metrics-port`) are exempted.
+All other flags must start with a known provider prefix (`twitch-`
+or `discord-`). Runs as part of `make ci` via `go test`.
+
+### 5. Prior plan doc updated (`docs/plan-container-non-root.md`)
+
+Updated config table to reflect new key names with a note
+referencing this plan document.
+
+## Breaking Changes
+
+1. **Env vars**: `DWARFBOT_TOKEN`, `DWARFBOT_CHANNELS`,
+   `DWARFBOT_SERVER`, `DWARFBOT_PORT` no longer work. Use
+   `DWARFBOT_TWITCH_TOKEN`, `DWARFBOT_TWITCH_CHANNELS`,
+   `DWARFBOT_TWITCH_SERVER`, `DWARFBOT_TWITCH_PORT`.
+2. **CLI flags**: `--server`/`-s`, `--port`/`-p`,
+   `--channels`/`-c` removed. Use `--twitch-server`,
+   `--twitch-port`, `--twitch-channels`.
+3. **Config file keys**: `token`, `channels`, `server`, `port`
+   in `.dwarfbot.yaml` must become `twitch_token`,
+   `twitch_channels`, `twitch_server`, `twitch_port`.
+
+## Migration Guide
+
+Update environment variables:
+```sh
+# Before
+export DWARFBOT_TOKEN=oauth:abc123
+export DWARFBOT_CHANNELS=mychannel
+export DWARFBOT_SERVER=irc.chat.twitch.tv
+export DWARFBOT_PORT=6667
+
+# After
+export DWARFBOT_TWITCH_TOKEN=oauth:abc123
+export DWARFBOT_TWITCH_CHANNELS=mychannel
+export DWARFBOT_TWITCH_SERVER=irc.chat.twitch.tv
+export DWARFBOT_TWITCH_PORT=6667
+```
+
+Update config file (`~/.dwarfbot.yaml`):
+```yaml
+# Before
+token: oauth:abc123
+channels:
+  - mychannel
+
+# After
+twitch_token: oauth:abc123
+twitch_channels:
+  - mychannel
+```
+
+## Verification
+
+- `make ci` passes (fmt, vet, test, build)
+- `TestConfigKeyNamingConvention` catches non-compliant flags
+- Existing tests updated and passing with new key names
+
+## Post-Mortem
+
+_To be filled after PR review._
+
+### What Went Well
+
+### What Went Wrong
+
+### Lessons Learned


### PR DESCRIPTION
## Summary

- Rename Twitch-specific config keys (`token`, `channels`, `server`, `port`) to use `twitch_` prefix, matching the existing Discord key pattern (`DWARFBOT_DISCORD_*`)
- Add `TestFlagNamingConvention` CI test that validates all non-general CLI flags follow the `<provider>-<item>` naming convention
- Add configuration reference to README.md with full env var/flag/config key tables and usage examples

## Breaking Changes

| Old Env Var | New Env Var |
| --- | --- |
| `DWARFBOT_TOKEN` | `DWARFBOT_TWITCH_TOKEN` |
| `DWARFBOT_CHANNELS` | `DWARFBOT_TWITCH_CHANNELS` |
| `DWARFBOT_SERVER` | `DWARFBOT_TWITCH_SERVER` |
| `DWARFBOT_PORT` | `DWARFBOT_TWITCH_PORT` |

CLI flags `--server`/`-s`, `--port`/`-p`, `--channels`/`-c` are replaced by `--twitch-server`, `--twitch-port`, `--twitch-channels`. A new `--twitch-token` flag is added for consistency with `--discord-token`.

General settings (`name`, `verbose`, `metrics_port`) are unchanged.

## Test plan

- [x] `make ci` passes (fmt, vet, test, build)
- [x] `TestFlagNamingConvention` catches non-compliant flags
- [x] All existing tests updated and passing with new key names
- [ ] Manual: `DWARFBOT_TWITCH_TOKEN=x DWARFBOT_TWITCH_CHANNELS=test DWARFBOT_NAME=bot ./out/dwarfbot` starts with expected connection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)