### PR TITLE
Fix MQTT bridge reconnection storm and Discord spam

### DIFF
--- a/pkg/mqtt/bridge.go
+++ b/pkg/mqtt/bridge.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -19,17 +20,20 @@ type BridgeStatus struct {
 }
 
 type Bridge struct {
-	config        Config
-	buffer        *Buffer
-	metrics       *BridgeMetrics
-	postFunc      PostFunc
-	clientFactory ClientFactory
-	client        MQTTClient
-	mu            sync.Mutex
-	enabled       bool
-	connected     bool
-	stopCh        chan struct{}
-	stopped       bool
+	config         Config
+	buffer         *Buffer
+	metrics        *BridgeMetrics
+	postFunc       PostFunc
+	clientFactory  ClientFactory
+	client         MQTTClient
+	mu             sync.Mutex
+	enabled        bool
+	connected      bool
+	stopCh         chan struct{}
+	stopped        bool
+	reconnecting   bool
+	lastNotifyTime time.Time
+	nowFunc        func() time.Time
 }
 
 func NewBridge(cfg Config, postFunc PostFunc, metrics *BridgeMetrics) *Bridge {
@@ -40,6 +44,7 @@ func NewBridge(cfg Config, postFunc PostFunc, metrics *BridgeMetrics) *Bridge {
 		postFunc:      postFunc,
 		clientFactory: DefaultClientFactory,
 		enabled:       cfg.Enabled,
+		nowFunc:       time.Now,
 	}
 }
 
@@ -51,6 +56,7 @@ func NewBridgeWithFactory(cfg Config, postFunc PostFunc, metrics *BridgeMetrics,
 		postFunc:      postFunc,
 		clientFactory: factory,
 		enabled:       cfg.Enabled,
+		nowFunc:       time.Now,
 	}
 }
 
@@ -65,7 +71,7 @@ func (b *Bridge) Start() error {
 
 	if err := b.connect(); err != nil {
 		log.Printf("MQTT bridge: initial connection failed: %v", err)
-		b.notifyDiscord(fmt.Sprintf("MQTT bridge failed to connect: %v — will retry", err))
+		b.notifyDiscordThrottled(fmt.Sprintf("MQTT bridge failed to connect: %v — will retry", err))
 		go b.reconnectLoop()
 	}
 
@@ -81,10 +87,11 @@ func (b *Bridge) Stop() {
 	}
 	b.stopped = true
 	close(b.stopCh)
+	client := b.client
 	b.mu.Unlock()
 
-	if b.client != nil && b.client.IsConnected() {
-		b.client.Disconnect(250)
+	if client != nil && client.IsConnected() {
+		client.Disconnect(250)
 	}
 
 	b.mu.Lock()
@@ -98,8 +105,14 @@ func (b *Bridge) Stop() {
 }
 
 func (b *Bridge) connect() error {
-	b.client = b.clientFactory(b.config, b.onConnectionLost, b.onConnect)
-	token := b.client.Connect()
+	b.mu.Lock()
+	if b.client == nil {
+		b.client = b.clientFactory(b.config, b.onConnectionLost, b.onConnect)
+	}
+	client := b.client
+	b.mu.Unlock()
+
+	token := client.Connect()
 	token.Wait()
 	if err := token.Error(); err != nil {
 		return fmt.Errorf("MQTT connect: %w", err)
@@ -112,21 +125,33 @@ func (b *Bridge) connect() error {
 	}
 	b.mu.Unlock()
 
-	b.subscribe()
+	if err := b.subscribe(); err != nil {
+		return fmt.Errorf("MQTT subscribe: %w", err)
+	}
 	log.Printf("MQTT bridge connected to %s", b.config.Broker)
 	return nil
 }
 
-func (b *Bridge) subscribe() {
+func (b *Bridge) subscribe() error {
+	b.mu.Lock()
+	client := b.client
+	b.mu.Unlock()
+	if client == nil {
+		return fmt.Errorf("no MQTT client")
+	}
+
+	var errs []error
 	for _, topic := range b.config.Topics {
-		token := b.client.Subscribe(topic, 0, b.messageHandler)
+		token := client.Subscribe(topic, 0, b.messageHandler)
 		token.Wait()
 		if err := token.Error(); err != nil {
 			log.Printf("MQTT bridge: failed to subscribe to %s: %v", topic, err)
+			errs = append(errs, fmt.Errorf("topic %s: %w", topic, err))
 		} else {
 			log.Printf("MQTT bridge: subscribed to %s", topic)
 		}
 	}
+	return errors.Join(errs...)
 }
 
 func (b *Bridge) messageHandler(_ pahomqtt.Client, msg pahomqtt.Message) {
@@ -158,7 +183,7 @@ func (b *Bridge) onConnectionLost(_ pahomqtt.Client, err error) {
 	b.mu.Unlock()
 
 	if !stopped {
-		b.notifyDiscord(fmt.Sprintf("MQTT bridge connection lost: %v — will reconnect", err))
+		b.notifyDiscordThrottled(fmt.Sprintf("MQTT bridge connection lost: %v — will reconnect", err))
 		go b.reconnectLoop()
 	}
 }
@@ -171,11 +196,26 @@ func (b *Bridge) onConnect(_ pahomqtt.Client) {
 	}
 	b.mu.Unlock()
 
-	b.subscribe()
+	if err := b.subscribe(); err != nil {
+		log.Printf("MQTT bridge: resubscribe after reconnect failed: %v", err)
+	}
 	log.Println("MQTT bridge: reconnected")
 }
 
 func (b *Bridge) reconnectLoop() {
+	b.mu.Lock()
+	if b.reconnecting {
+		b.mu.Unlock()
+		return
+	}
+	b.reconnecting = true
+	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		b.reconnecting = false
+		b.mu.Unlock()
+	}()
+
 	maxRetries := 10
 	for attempt := range maxRetries {
 		b.mu.Lock()
@@ -250,6 +290,25 @@ func (b *Bridge) flush() {
 	if b.metrics != nil {
 		b.metrics.RecordForwarded(forwarded)
 	}
+}
+
+const notifyCooldown = 5 * time.Minute
+
+func (b *Bridge) notifyDiscordThrottled(msg string) {
+	b.mu.Lock()
+	now := b.nowFunc()
+	if !b.lastNotifyTime.IsZero() && now.Sub(b.lastNotifyTime) < notifyCooldown {
+		b.mu.Unlock()
+		log.Printf("MQTT bridge: suppressing Discord notification (cooldown): %s", msg)
+		if b.metrics != nil {
+			b.metrics.RecordSuppressed(1)
+		}
+		return
+	}
+	b.lastNotifyTime = now
+	b.mu.Unlock()
+
+	b.notifyDiscord(msg)
 }
 
 func (b *Bridge) notifyDiscord(msg string) {

--- a/pkg/mqtt/bridge_test.go
+++ b/pkg/mqtt/bridge_test.go
@@ -828,6 +828,75 @@ func TestBridge_NotifyDiscord_PostsToAllChannels(t *testing.T) {
 	}
 }
 
+func TestBridge_NotifyDiscordThrottled_FirstCallSends(t *testing.T) {
+	client := newMockClient(nil)
+	collector := &messageCollector{}
+	b, _ := newTestBridge(t, client, collector)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.nowFunc = func() time.Time { return now }
+
+	b.notifyDiscordThrottled("first alert")
+
+	msgs := collector.getMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+}
+
+func TestBridge_NotifyDiscordThrottled_WithinCooldownSuppressed(t *testing.T) {
+	client := newMockClient(nil)
+	collector := &messageCollector{}
+	b, _ := newTestBridge(t, client, collector)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.nowFunc = func() time.Time { return now }
+
+	b.notifyDiscordThrottled("first alert")
+	b.notifyDiscordThrottled("second alert")
+	b.notifyDiscordThrottled("third alert")
+
+	msgs := collector.getMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message (others suppressed), got %d", len(msgs))
+	}
+}
+
+func TestBridge_NotifyDiscordThrottled_AfterCooldownSendsAgain(t *testing.T) {
+	client := newMockClient(nil)
+	collector := &messageCollector{}
+	b, _ := newTestBridge(t, client, collector)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.nowFunc = func() time.Time { return now }
+	b.notifyDiscordThrottled("first alert")
+
+	now = now.Add(6 * time.Minute)
+	b.notifyDiscordThrottled("second alert after cooldown")
+
+	msgs := collector.getMessages()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (cooldown expired), got %d", len(msgs))
+	}
+}
+
+func TestBridge_NotifyDiscord_ExhaustedRetries_NotThrottled(t *testing.T) {
+	client := newMockClient(nil)
+	collector := &messageCollector{}
+	b, _ := newTestBridge(t, client, collector)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.nowFunc = func() time.Time { return now }
+
+	b.notifyDiscordThrottled("connection lost")
+	b.notifyDiscord("exhausted reconnect attempts — bridge is offline")
+
+	msgs := collector.getMessages()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages (un-throttled notifyDiscord bypasses cooldown), got %d", len(msgs))
+	}
+}
+
 func TestBridge_OnConnectionLost_SetsDisconnected(t *testing.T) {
 	client := newMockClient(nil)
 	collector := &messageCollector{}
@@ -900,7 +969,9 @@ func TestBridge_Subscribe_RecordsTopics(t *testing.T) {
 	b, _ := newTestBridge(t, client, collector)
 	b.client = client
 
-	b.subscribe()
+	if err := b.subscribe(); err != nil {
+		t.Fatalf("unexpected subscribe error: %v", err)
+	}
 
 	subs := client.getSubscriptions()
 	if len(subs) != 2 {
@@ -915,7 +986,104 @@ func TestBridge_Subscribe_HandleError(t *testing.T) {
 	b, _ := newTestBridge(t, client, collector)
 	b.client = client
 
-	b.subscribe()
+	err := b.subscribe()
+	if err == nil {
+		t.Fatal("expected error from subscribe with failing topic")
+	}
+}
+
+func TestBridge_ReconnectLoop_NoDuplicateGoroutines(t *testing.T) {
+	client := newMockClient(fmt.Errorf("connection refused"))
+	collector := &messageCollector{}
+	cf := newCountingFactory(client)
+	reg := prometheus.NewRegistry()
+	m := NewBridgeMetrics(reg)
+	cfg := Config{
+		Enabled:          true,
+		Broker:           "tcp://test:1883",
+		Topics:           []string{"home/#"},
+		MaxBuffer:        10,
+		MaxPayloadBytes:  128,
+		MaxPostsPerFlush: 3,
+		FlushSeconds:     60,
+		DiscordChannels:  []string{"ch1"},
+	}
+	b := NewBridgeWithFactory(cfg, collector.post, m, cf.factory())
+	b.stopCh = make(chan struct{})
+
+	go b.reconnectLoop()
+	time.Sleep(20 * time.Millisecond)
+
+	b.mu.Lock()
+	isReconnecting := b.reconnecting
+	b.mu.Unlock()
+	if !isReconnecting {
+		t.Fatal("expected reconnecting to be true while reconnectLoop is running")
+	}
+
+	b.reconnectLoop()
+
+	callsAfterSecond := cf.getCalls()
+	if callsAfterSecond != 0 {
+		t.Fatalf("second reconnectLoop should have returned immediately, but factory was called %d times", callsAfterSecond)
+	}
+
+	close(b.stopCh)
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestBridge_ReconnectLoop_ResetsAfterCompletion(t *testing.T) {
+	client := newMockClient(nil)
+	collector := &messageCollector{}
+	b, _ := newTestBridge(t, client, collector)
+
+	b.mu.Lock()
+	b.stopCh = make(chan struct{})
+	b.stopped = false
+	b.mu.Unlock()
+
+	b.reconnectLoop()
+
+	b.mu.Lock()
+	isReconnecting := b.reconnecting
+	b.mu.Unlock()
+	if isReconnecting {
+		t.Fatal("expected reconnecting to be false after reconnectLoop completes")
+	}
+}
+
+func TestBridge_Connect_ReusesClient(t *testing.T) {
+	client := newMockClient(nil)
+	cf := newCountingFactory(client)
+	collector := &messageCollector{}
+	reg := prometheus.NewRegistry()
+	m := NewBridgeMetrics(reg)
+	cfg := Config{
+		Enabled:          true,
+		Broker:           "tcp://test:1883",
+		Topics:           []string{"home/#"},
+		MaxBuffer:        10,
+		MaxPayloadBytes:  128,
+		MaxPostsPerFlush: 3,
+		FlushSeconds:     5,
+		DiscordChannels:  []string{"ch1"},
+	}
+	b := NewBridgeWithFactory(cfg, collector.post, m, cf.factory())
+
+	if err := b.connect(); err != nil {
+		t.Fatalf("first connect failed: %v", err)
+	}
+	if cf.getCalls() != 1 {
+		t.Fatalf("expected 1 factory call after first connect, got %d", cf.getCalls())
+	}
+
+	client.Disconnect(0)
+	if err := b.connect(); err != nil {
+		t.Fatalf("second connect failed: %v", err)
+	}
+	if cf.getCalls() != 1 {
+		t.Fatalf("expected factory call count to remain 1 after reconnect, got %d", cf.getCalls())
+	}
 }
 
 func TestNewBridgeWithFactory_UsesCustomFactory(t *testing.T) {

--- a/pkg/mqtt/client.go
+++ b/pkg/mqtt/client.go
@@ -17,7 +17,7 @@ func DefaultClientFactory(cfg Config, onConnLost pahomqtt.ConnectionLostHandler,
 	opts := pahomqtt.NewClientOptions().
 		AddBroker(cfg.Broker).
 		SetClientID(cfg.ClientID).
-		SetAutoReconnect(true).
+		SetAutoReconnect(false).
 		SetConnectionLostHandler(onConnLost).
 		SetOnConnectHandler(onConnect)
 

--- a/pkg/mqtt/mock_client_test.go
+++ b/pkg/mqtt/mock_client_test.go
@@ -95,6 +95,31 @@ func mockFactory(client *mockClient) ClientFactory {
 var _ MQTTClient = (*mockClient)(nil)
 var _ pahomqtt.Message = (*mockMessage)(nil)
 
+type countingFactory struct {
+	client *mockClient
+	mu     sync.Mutex
+	calls  int
+}
+
+func newCountingFactory(client *mockClient) *countingFactory {
+	return &countingFactory{client: client}
+}
+
+func (f *countingFactory) factory() ClientFactory {
+	return func(cfg Config, onConnLost pahomqtt.ConnectionLostHandler, onConnect pahomqtt.OnConnectHandler) MQTTClient {
+		f.mu.Lock()
+		f.calls++
+		f.mu.Unlock()
+		return f.client
+	}
+}
+
+func (f *countingFactory) getCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
 type messageCollector struct {
 	mu       sync.Mutex
 	messages []struct{ channel, msg string }


### PR DESCRIPTION
## Summary

- Fix infinite reconnect cascade caused by paho auto-reconnect competing with the bridge's own `reconnectLoop()` — each created connections with the same ClientID that Mosquitto killed, triggering cascading `onConnectionLost` callbacks
- Add mutex protection for `b.client`, duplicate goroutine guard, client reuse, subscribe error propagation, and 5-minute Discord notification throttling
- MQTT is currently disabled in cluster-config to stop the spam; this fix allows re-enabling it

## Changes (applied incrementally, tests green at each step)

1. **subscribe() returns errors** — callers can now detect subscription failures
2. **b.client mutex protection** — prevents data races in connect/subscribe/Stop
3. **Client reuse** — factory only called once; reconnects reuse existing paho client
4. **Disable paho auto-reconnect** — bridge's reconnectLoop is the sole reconnection mechanism
5. **Reconnect guard** — `reconnecting` bool prevents duplicate reconnectLoop goroutines
6. **Discord throttling** — `notifyDiscordThrottled()` with 5-min cooldown; "exhausted retries" stays un-throttled

## Test plan

- [x] `make ci` passes (fmt, vet, test -race, build)
- [x] 8 new/updated tests cover: subscribe error return, client reuse, reconnect guard dedup, reconnect guard reset, throttle first-call, throttle suppression, throttle cooldown expiry, un-throttled exhausted retries
- [ ] Build and push new image
- [ ] Update cluster-config deployment tag and set `DWARFBOT_MQTT_ENABLED: "true"`
- [ ] Verify with `mosquitto_pub` against live Mosquitto 2.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)