### PR TITLE
Fix Viper env var comma splitting for StringSlice configs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,13 +66,13 @@ var rootCmd = &cobra.Command{
 
 		// Twitch config
 		twitchToken := viper.GetString("twitch_token")
-		twitchChannels := viper.GetStringSlice("twitch_channels")
+		twitchChannels := getStringSlice("twitch_channels")
 		server := viper.GetString("twitch_server")
 		port := viper.GetString("twitch_port")
 
 		// Discord config
 		discordToken := viper.GetString("discord_token")
-		discordChannels := viper.GetStringSlice("discord_channels")
+		discordChannels := getStringSlice("discord_channels")
 		discordAdminRole := viper.GetString("discord_admin_role")
 
 		twitchEnabled := twitchToken != "" && len(twitchChannels) > 0
@@ -83,7 +83,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// MQTT config
-		mqttDiscordChannels := viper.GetStringSlice("mqtt_discord_channels")
+		mqttDiscordChannels := getStringSlice("mqtt_discord_channels")
 		if len(mqttDiscordChannels) == 0 {
 			mqttDiscordChannels = discordChannels
 		}
@@ -93,7 +93,7 @@ var rootCmd = &cobra.Command{
 			Username:         viper.GetString("mqtt_username"),
 			Password:         viper.GetString("mqtt_password"),
 			ClientID:         viper.GetString("mqtt_client_id"),
-			Topics:           viper.GetStringSlice("mqtt_topics"),
+			Topics:           getStringSlice("mqtt_topics"),
 			DiscordChannels:  mqttDiscordChannels,
 			FlushSeconds:     viper.GetInt("mqtt_flush_seconds"),
 			MaxBuffer:        viper.GetInt("mqtt_max_buffer"),
@@ -354,6 +354,20 @@ func init() {
 
 	rootCmd.PersistentFlags().Int("mqtt-max-posts-per-flush", 5, "Maximum Discord messages per flush (outbound rate cap)")
 	cobra.CheckErr(viper.BindPFlag("mqtt_max_posts_per_flush", rootCmd.PersistentFlags().Lookup("mqtt-max-posts-per-flush")))
+}
+
+func getStringSlice(key string) []string {
+	v := viper.GetStringSlice(key)
+	if len(v) == 1 && strings.Contains(v[0], ",") {
+		var out []string
+		for _, s := range strings.Split(v[0], ",") {
+			if t := strings.TrimSpace(s); t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+	return v
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -243,6 +243,61 @@ func TestInitConfig_DiscordEnvVars(t *testing.T) {
 	}
 }
 
+// --- getStringSlice tests ---
+
+func TestGetStringSlice_CommaSeparatedEnvVar(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DWARFBOT_MQTT_TOPICS", "home/#,ai/#,system/#")
+	savedCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = savedCfgFile }()
+
+	viper.Reset()
+	initConfig()
+
+	got := getStringSlice("mqtt_topics")
+	if len(got) != 3 {
+		t.Fatalf("expected 3 topics, got %d: %v", len(got), got)
+	}
+	if got[0] != "home/#" || got[1] != "ai/#" || got[2] != "system/#" {
+		t.Errorf("expected [home/# ai/# system/#], got %v", got)
+	}
+}
+
+func TestGetStringSlice_SingleValue(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DWARFBOT_TWITCH_CHANNELS", "hammerdwarf")
+	savedCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = savedCfgFile }()
+
+	viper.Reset()
+	initConfig()
+
+	got := getStringSlice("twitch_channels")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 channel, got %d: %v", len(got), got)
+	}
+	if got[0] != "hammerdwarf" {
+		t.Errorf("expected [hammerdwarf], got %v", got)
+	}
+}
+
+func TestGetStringSlice_EmptyValue(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	savedCfgFile := cfgFile
+	cfgFile = ""
+	defer func() { cfgFile = savedCfgFile }()
+
+	viper.Reset()
+	initConfig()
+
+	got := getStringSlice("mqtt_topics")
+	if len(got) != 0 {
+		t.Fatalf("expected 0 topics for unset key, got %d: %v", len(got), got)
+	}
+}
+
 // --- Flag usage/help text tests ---
 
 func TestFlagsHaveUsageText(t *testing.T) {

--- a/docs/plans/2026-06-23_mqtt-discord-mouthpiece.md
+++ b/docs/plans/2026-06-23_mqtt-discord-mouthpiece.md
@@ -108,4 +108,32 @@ The bridge never triggers a dwarfbot shutdown. There is no `mqttErrCh` in the `r
 
 ## Lessons Learned
 
-To be updated after implementation review and CI feedback.
+Updated 2026-07-01 after production deployment revealed a reconnection storm and Discord notification flood (PR #17, PR #18).
+
+### Bug 1: Dual competing reconnection mechanisms
+
+Paho's `SetAutoReconnect(true)` and the bridge's own `reconnectLoop()` both fired on connection loss. Each created connections with the same ClientID, causing Mosquitto to kill the older connection — which triggered another `onConnectionLost`, creating an infinite cascade. **Lesson:** When implementing your own reconnection logic with backoff, always disable the library's built-in auto-reconnect. Two reconnect paths with the same ClientID will fight.
+
+### Bug 2: New client created on every reconnect
+
+`connect()` called the client factory every time, creating a fresh paho client without disconnecting the old one. The dereferenced client kept its connection alive, so two clients with the same ClientID existed simultaneously. **Lesson:** Reuse the existing client object for reconnection — paho's `Connect()` works on a disconnected client. Only create the client once.
+
+### Bug 3: No guard against duplicate reconnectLoop goroutines
+
+`onConnectionLost` spawned `go reconnectLoop()` unconditionally. Multiple concurrent loops amplified the ClientID collision problem. **Lesson:** Any callback that spawns a goroutine needs a guard to prevent duplicates, especially callbacks that can fire rapidly (like connection-lost handlers).
+
+### Bug 4: Discord notification spam
+
+`notifyDiscord()` was called from `onConnectionLost` with no rate limiting. In the reconnect storm this fired dozens of times per second. **Lesson:** Any notification path reachable from a retry loop or error callback needs throttling. A 5-minute cooldown with an injectable clock (`nowFunc`) for testability is the right pattern.
+
+### Bug 5: b.client field unprotected by mutex
+
+`b.client` was read and written from multiple goroutines (`connect()`, `Stop()`, `subscribe()`) without mutex protection. **Lesson:** Any field accessed from callbacks, goroutines, and the main path needs synchronization. Use minimal lock scope — snapshot the reference under the lock, then use the local copy for blocking I/O.
+
+### Bug 6: subscribe() errors silently ignored
+
+`subscribe()` logged errors but returned nothing. The bridge could report "connected" while having no active subscriptions. **Lesson:** Internal methods that can fail should return errors so callers can react. Silent logging is not error handling.
+
+### Bug 7: Viper GetStringSlice does not split env var commas
+
+`viper.GetStringSlice("mqtt_topics")` with env var `DWARFBOT_MQTT_TOPICS=home/#,ai/#,system/#` treated the entire value as one string. Mosquitto rejected the invalid topic filter containing commas, causing immediate EOF disconnection. This is a well-known Viper limitation. **Lesson:** When using Viper with env vars for string slices, add a wrapper that detects single-element slices containing commas and splits them. This affected all four `StringSlice` config keys (twitch channels, discord channels, mqtt topics, mqtt discord channels).


### PR DESCRIPTION
## Summary

- Fix Viper `GetStringSlice` treating comma-separated env var values (e.g. `DWARFBOT_MQTT_TOPICS=home/#,ai/#,system/#`) as a single string instead of splitting them — this caused Mosquitto to reject the invalid topic filter and disconnect with EOF
- Add `getStringSlice` wrapper applied to all 4 `StringSlice` config keys (twitch channels, discord channels, mqtt topics, mqtt discord channels)
- Update MQTT bridge plan `docs/plans/2026-06-23_mqtt-discord-mouthpiece.md` with lessons learned from PR #17 reconnection storm fix and this env var parsing bug

## Test plan

- [x] `make ci` passes (fmt, vet, test -race, build)
- [x] New tests: `TestGetStringSlice_CommaSeparatedEnvVar`, `TestGetStringSlice_SingleValue`, `TestGetStringSlice_EmptyValue`
- [ ] After merge and deploy, verify MQTT bridge subscribes to 3 separate topics (not one concatenated string)
- [ ] Verify with `mosquitto_pub -t "home/test" -m "Hello"` that messages arrive in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)